### PR TITLE
feat(folders): implement full folder CRUD with file-folder association

### DIFF
--- a/__tests__/auth.test.js
+++ b/__tests__/auth.test.js
@@ -9,6 +9,7 @@ jest.mock('connect-pg-simple', () => {
 
 jest.mock('../src/models/userModel');
 jest.mock('../src/models/fileModel');
+jest.mock('../src/models/folderModel');
 jest.mock('../src/config/supabase', () => ({
   storage: {
     from: jest.fn(() => ({
@@ -21,6 +22,7 @@ jest.mock('../src/config/supabase', () => ({
 
 const userModel = require('../src/models/userModel');
 const fileModel = require('../src/models/fileModel');
+const folderModel = require('../src/models/folderModel');
 
 const app = require('../src/app');
 
@@ -34,6 +36,7 @@ const FAKE_USER = {
 beforeEach(() => {
   jest.clearAllMocks();
   fileModel.getFilesByUser.mockResolvedValue([]);
+  folderModel.getFoldersByUser.mockResolvedValue([]);
 });
 
 describe('GET /signup', () => {

--- a/__tests__/file.test.js
+++ b/__tests__/file.test.js
@@ -9,6 +9,7 @@ jest.mock('connect-pg-simple', () => {
 
 jest.mock('../src/models/userModel');
 jest.mock('../src/models/fileModel');
+jest.mock('../src/models/folderModel');
 jest.mock('../src/config/supabase', () => ({
   storage: {
     from: jest.fn(() => ({
@@ -21,6 +22,7 @@ jest.mock('../src/config/supabase', () => ({
 
 const userModel = require('../src/models/userModel');
 const fileModel = require('../src/models/fileModel');
+const folderModel = require('../src/models/folderModel');
 const app = require('../src/app');
 
 const FAKE_USER = {
@@ -55,6 +57,7 @@ const loginAgent = async () => {
 beforeEach(() => {
   jest.clearAllMocks();
   fileModel.getFilesByUser.mockResolvedValue([]);
+  folderModel.getFoldersByUser.mockResolvedValue([]);
 });
 
 describe('GET /dashboard', () => {
@@ -64,14 +67,16 @@ describe('GET /dashboard', () => {
     expect(res.headers.location).toBe('/login');
   });
 
-  test('renders dashboard for authenticated users and calls getFilesByUser', async () => {
+  test('renders dashboard for authenticated users and calls getFilesByUser and getFoldersByUser', async () => {
     fileModel.getFilesByUser.mockResolvedValue([FAKE_FILE]);
+    folderModel.getFoldersByUser.mockResolvedValue([]);
     const agent = await loginAgent();
 
     const res = await agent.get('/dashboard');
     expect(res.status).toBe(200);
     expect(res.text).toContain('Welcome');
     expect(fileModel.getFilesByUser).toHaveBeenCalledWith(FAKE_USER.id);
+    expect(folderModel.getFoldersByUser).toHaveBeenCalledWith(FAKE_USER.id);
   });
 });
 

--- a/__tests__/folder.test.js
+++ b/__tests__/folder.test.js
@@ -1,0 +1,228 @@
+const request = require('supertest');
+
+jest.mock('connect-pg-simple', () => {
+  return () => {
+    const session = require('express-session');
+    return session.MemoryStore;
+  };
+});
+
+jest.mock('../src/models/userModel');
+jest.mock('../src/models/fileModel');
+jest.mock('../src/models/folderModel');
+jest.mock('../src/config/supabase', () => ({
+  storage: {
+    from: jest.fn(() => ({
+      upload: jest.fn().mockResolvedValue({ data: {}, error: null }),
+      getPublicUrl: jest.fn().mockReturnValue({ data: { publicUrl: 'https://test.supabase.co/object/public/test-bucket/user-id/test-file.txt' } }),
+      remove: jest.fn().mockResolvedValue({ data: {}, error: null }),
+    })),
+  },
+}));
+
+const userModel = require('../src/models/userModel');
+const fileModel = require('../src/models/fileModel');
+const folderModel = require('../src/models/folderModel');
+const app = require('../src/app');
+
+const FAKE_USER = {
+  id: 'uuid-test-1',
+  email: 'test@example.com',
+  password: '$2b$12$hashedpassword',
+  name: 'Test User',
+};
+
+const FAKE_FOLDER = {
+  id: 'folder-uuid-1',
+  name: 'My Folder',
+  userId: 'uuid-test-1',
+  createdAt: new Date(),
+  updatedAt: new Date(),
+  _count: { files: 0 },
+};
+
+const FAKE_FILE = {
+  id: 'file-uuid-1',
+  name: 'test.txt',
+  type: 'text/plain',
+  size: 1024,
+  url: 'https://test.supabase.co/object/public/test-bucket/uuid-test-1/test-file.txt',
+  userId: 'uuid-test-1',
+  folderId: 'folder-uuid-1',
+  createdAt: new Date(),
+  updatedAt: new Date(),
+};
+
+const loginAgent = async () => {
+  const bcrypt = require('bcrypt');
+  const hashedPassword = await bcrypt.hash('password123', 1);
+  userModel.findByEmail.mockResolvedValue({ ...FAKE_USER, password: hashedPassword });
+  userModel.findById.mockResolvedValue(FAKE_USER);
+
+  const agent = request.agent(app);
+  await agent.post('/login').send({ email: 'test@example.com', password: 'password123' });
+  return agent;
+};
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  fileModel.getFilesByUser.mockResolvedValue([]);
+  fileModel.getFilesInFolder.mockResolvedValue([]);
+  folderModel.getFoldersByUser.mockResolvedValue([]);
+});
+
+describe('GET /dashboard', () => {
+  test('calls getFoldersByUser and getFilesByUser when authenticated', async () => {
+    folderModel.getFoldersByUser.mockResolvedValue([FAKE_FOLDER]);
+    fileModel.getFilesByUser.mockResolvedValue([FAKE_FILE]);
+    const agent = await loginAgent();
+
+    const res = await agent.get('/dashboard');
+    expect(res.status).toBe(200);
+    expect(folderModel.getFoldersByUser).toHaveBeenCalledWith(FAKE_USER.id);
+    expect(fileModel.getFilesByUser).toHaveBeenCalledWith(FAKE_USER.id);
+  });
+
+  test('GET /dashboard?view=flat returns 200', async () => {
+    const agent = await loginAgent();
+    const res = await agent.get('/dashboard?view=flat');
+    expect(res.status).toBe(200);
+  });
+});
+
+describe('GET /folders/:id', () => {
+  test('redirects unauthenticated users to /login', async () => {
+    const res = await request(app).get('/folders/folder-uuid-1');
+    expect(res.status).toBe(302);
+    expect(res.headers.location).toBe('/login');
+  });
+
+  test('renders folder view for owner', async () => {
+    folderModel.getFolderById.mockResolvedValue(FAKE_FOLDER);
+    fileModel.getFilesInFolder.mockResolvedValue([FAKE_FILE]);
+    folderModel.getFoldersByUser.mockResolvedValue([FAKE_FOLDER]);
+    const agent = await loginAgent();
+
+    const res = await agent.get(`/folders/${FAKE_FOLDER.id}`);
+    expect(res.status).toBe(200);
+    expect(folderModel.getFolderById).toHaveBeenCalledWith(FAKE_FOLDER.id);
+  });
+
+  test('redirects to /dashboard when folder not found', async () => {
+    folderModel.getFolderById.mockResolvedValue(null);
+    const agent = await loginAgent();
+
+    const res = await agent.get('/folders/nonexistent-id');
+    expect(res.status).toBe(302);
+    expect(res.headers.location).toBe('/dashboard');
+  });
+
+  test('redirects to /dashboard when user does not own folder', async () => {
+    folderModel.getFolderById.mockResolvedValue({ ...FAKE_FOLDER, userId: 'other-user-id' });
+    const agent = await loginAgent();
+
+    const res = await agent.get(`/folders/${FAKE_FOLDER.id}`);
+    expect(res.status).toBe(302);
+    expect(res.headers.location).toBe('/dashboard');
+  });
+});
+
+describe('POST /folders', () => {
+  test('redirects unauthenticated users to /login', async () => {
+    const res = await request(app).post('/folders').send({ name: 'New Folder' });
+    expect(res.status).toBe(302);
+    expect(res.headers.location).toBe('/login');
+  });
+
+  test('creates folder and redirects to /dashboard', async () => {
+    folderModel.createFolder.mockResolvedValue(FAKE_FOLDER);
+    const agent = await loginAgent();
+
+    const res = await agent.post('/folders').send({ name: 'New Folder' });
+    expect(res.status).toBe(302);
+    expect(res.headers.location).toBe('/dashboard');
+    expect(folderModel.createFolder).toHaveBeenCalledWith(
+      expect.objectContaining({ name: 'New Folder', userId: FAKE_USER.id })
+    );
+  });
+
+  test('flashes error and redirects when name is missing', async () => {
+    const agent = await loginAgent();
+
+    const res = await agent.post('/folders').send({ name: '' });
+    expect(res.status).toBe(302);
+    expect(res.headers.location).toBe('/dashboard');
+    expect(folderModel.createFolder).not.toHaveBeenCalled();
+  });
+});
+
+describe('POST /folders/:id/rename', () => {
+  test('renames folder for owner and redirects', async () => {
+    folderModel.getFolderById.mockResolvedValue(FAKE_FOLDER);
+    folderModel.updateFolder.mockResolvedValue({ ...FAKE_FOLDER, name: 'Renamed' });
+    const agent = await loginAgent();
+
+    const res = await agent.post(`/folders/${FAKE_FOLDER.id}/rename`).send({ name: 'Renamed' });
+    expect(res.status).toBe(302);
+    expect(folderModel.updateFolder).toHaveBeenCalledWith(
+      FAKE_FOLDER.id,
+      expect.objectContaining({ name: 'Renamed' })
+    );
+  });
+
+  test('flashes error and redirects when user does not own folder', async () => {
+    folderModel.getFolderById.mockResolvedValue({ ...FAKE_FOLDER, userId: 'other-user-id' });
+    const agent = await loginAgent();
+
+    const res = await agent.post(`/folders/${FAKE_FOLDER.id}/rename`).send({ name: 'Renamed' });
+    expect(res.status).toBe(302);
+    expect(folderModel.updateFolder).not.toHaveBeenCalled();
+  });
+});
+
+describe('POST /folders/:id/delete', () => {
+  test('deletes folder for owner and redirects to /dashboard', async () => {
+    folderModel.getFolderById.mockResolvedValue(FAKE_FOLDER);
+    folderModel.deleteFolder.mockResolvedValue(FAKE_FOLDER);
+    const agent = await loginAgent();
+
+    const res = await agent.post(`/folders/${FAKE_FOLDER.id}/delete`);
+    expect(res.status).toBe(302);
+    expect(res.headers.location).toBe('/dashboard');
+    expect(folderModel.deleteFolder).toHaveBeenCalledWith(FAKE_FOLDER.id);
+  });
+
+  test('flashes error and redirects when user does not own folder', async () => {
+    folderModel.getFolderById.mockResolvedValue({ ...FAKE_FOLDER, userId: 'other-user-id' });
+    const agent = await loginAgent();
+
+    const res = await agent.post(`/folders/${FAKE_FOLDER.id}/delete`);
+    expect(res.status).toBe(302);
+    expect(folderModel.deleteFolder).not.toHaveBeenCalled();
+  });
+});
+
+describe('POST /files/:id/move', () => {
+  test('moves file for owner and redirects', async () => {
+    fileModel.getFileById.mockResolvedValue(FAKE_FILE);
+    fileModel.moveFile.mockResolvedValue({ ...FAKE_FILE, folderId: null });
+    const agent = await loginAgent();
+
+    const res = await agent
+      .post(`/files/${FAKE_FILE.id}/move`)
+      .send({ folderId: '' });
+    expect(res.status).toBe(302);
+    expect(fileModel.moveFile).toHaveBeenCalledWith(FAKE_FILE.id, null);
+  });
+
+  test('flashes error and redirects when user does not own file', async () => {
+    fileModel.getFileById.mockResolvedValue({ ...FAKE_FILE, userId: 'other-user-id' });
+    const agent = await loginAgent();
+
+    const res = await agent
+      .post(`/files/${FAKE_FILE.id}/move`)
+      .send({ folderId: 'folder-uuid-1' });
+    expect(res.status).toBe(302);
+    expect(fileModel.moveFile).not.toHaveBeenCalled();
+  });
+});

--- a/src/app.js
+++ b/src/app.js
@@ -6,6 +6,7 @@ const passport = require('./config/passport');
 const flash = require('express-flash');
 const authRoutes = require('./routes/authRoutes');
 const fileRoutes = require('./routes/fileRoutes');
+const folderRoutes = require('./routes/folderRoutes');
 
 const PgStore = connectPgSimple(session);
 const app = express();
@@ -39,6 +40,7 @@ app.use(flash());
 
 app.use(authRoutes);
 app.use(fileRoutes);
+app.use(folderRoutes);
 
 app.get('/api/test', (_req, res) => {
   res.json({ message: 'API is working!' });

--- a/src/controllers/authController.js
+++ b/src/controllers/authController.js
@@ -1,7 +1,7 @@
 const userModel = require('../models/userModel');
 
 const getSignup = (req, res) => {
-  res.render('signup', { messages: res.locals.messages });
+  res.render('signup');
 };
 
 const postSignup = async (req, res, next) => {
@@ -33,7 +33,7 @@ const postSignup = async (req, res, next) => {
 };
 
 const getLogin = (req, res) => {
-  res.render('login', { messages: res.locals.messages });
+  res.render('login');
 };
 
 const logout = (req, res, next) => {

--- a/src/controllers/fileController.js
+++ b/src/controllers/fileController.js
@@ -2,13 +2,26 @@ const path = require('path');
 const { randomUUID } = require('crypto');
 const supabase = require('../config/supabase');
 const fileModel = require('../models/fileModel');
+const folderModel = require('../models/folderModel');
 
 const BUCKET = process.env.SUPABASE_STORAGE_BUCKET;
 
 const getFiles = async (req, res, next) => {
   try {
-    const files = await fileModel.getFilesByUser(req.user.id);
-    res.render('dashboard', { user: req.user, files, messages: res.locals.messages });
+    const [folders, allFiles] = await Promise.all([
+      folderModel.getFoldersByUser(req.user.id),
+      fileModel.getFilesByUser(req.user.id),
+    ]);
+    const rootFiles = allFiles.filter((f) => !f.folderId);
+    const viewMode = req.query.view === 'flat' ? 'flat' : 'folder';
+    res.render('dashboard', {
+      user: req.user,
+      folders,
+      files: allFiles,
+      rootFiles,
+      viewMode,
+      messages: res.locals.messages,
+    });
   } catch (err) {
     next(err);
   }
@@ -39,10 +52,12 @@ const uploadFile = async (req, res, next) => {
       size: req.file.size,
       url: urlData.publicUrl,
       userId: req.user.id,
+      folderId: req.body.folderId || null,
     });
 
     req.flash('success', 'File uploaded successfully.');
-    res.redirect('/dashboard');
+    const dest = req.body.folderId ? `/folders/${req.body.folderId}` : '/dashboard';
+    res.redirect(dest);
   } catch (err) {
     next(err);
   }
@@ -80,4 +95,26 @@ const deleteFile = async (req, res, next) => {
   }
 };
 
-module.exports = { getFiles, uploadFile, deleteFile };
+const moveFile = async (req, res, next) => {
+  try {
+    const file = await fileModel.getFileById(req.params.id);
+
+    if (!file) {
+      req.flash('error', 'File not found.');
+      return res.redirect('/dashboard');
+    }
+
+    if (file.userId !== req.user.id) {
+      req.flash('error', 'You do not have permission to move this file.');
+      return res.redirect('/dashboard');
+    }
+
+    await fileModel.moveFile(req.params.id, req.body.folderId || null);
+    req.flash('success', 'File moved.');
+    res.redirect(req.get('Referrer') || '/dashboard');
+  } catch (err) {
+    next(err);
+  }
+};
+
+module.exports = { getFiles, uploadFile, deleteFile, moveFile };

--- a/src/controllers/fileController.js
+++ b/src/controllers/fileController.js
@@ -20,7 +20,6 @@ const getFiles = async (req, res, next) => {
       files: allFiles,
       rootFiles,
       viewMode,
-      messages: res.locals.messages,
     });
   } catch (err) {
     next(err);

--- a/src/controllers/folderController.js
+++ b/src/controllers/folderController.js
@@ -92,7 +92,6 @@ const viewFolder = async (req, res, next) => {
       folder,
       files,
       allFolders,
-      messages: res.locals.messages,
     });
   } catch (err) {
     next(err);

--- a/src/controllers/folderController.js
+++ b/src/controllers/folderController.js
@@ -1,0 +1,102 @@
+const folderModel = require('../models/folderModel');
+const fileModel = require('../models/fileModel');
+
+const createFolder = async (req, res, next) => {
+  const { name } = req.body;
+
+  if (!name || !name.trim()) {
+    req.flash('error', 'Folder name is required.');
+    return res.redirect('/dashboard');
+  }
+
+  try {
+    await folderModel.createFolder({ name: name.trim(), userId: req.user.id });
+    req.flash('success', 'Folder created.');
+    res.redirect('/dashboard');
+  } catch (err) {
+    next(err);
+  }
+};
+
+const renameFolder = async (req, res, next) => {
+  try {
+    const folder = await folderModel.getFolderById(req.params.id);
+
+    if (!folder) {
+      req.flash('error', 'Folder not found.');
+      return res.redirect('/dashboard');
+    }
+
+    if (folder.userId !== req.user.id) {
+      req.flash('error', 'You do not have permission to rename this folder.');
+      return res.redirect('/dashboard');
+    }
+
+    const { name } = req.body;
+    if (!name || !name.trim()) {
+      req.flash('error', 'Folder name is required.');
+      return res.redirect(req.get('Referrer') || '/dashboard');
+    }
+
+    await folderModel.updateFolder(req.params.id, { name: name.trim() });
+    req.flash('success', 'Folder renamed.');
+    res.redirect(req.get('Referrer') || '/dashboard');
+  } catch (err) {
+    next(err);
+  }
+};
+
+const deleteFolder = async (req, res, next) => {
+  try {
+    const folder = await folderModel.getFolderById(req.params.id);
+
+    if (!folder) {
+      req.flash('error', 'Folder not found.');
+      return res.redirect('/dashboard');
+    }
+
+    if (folder.userId !== req.user.id) {
+      req.flash('error', 'You do not have permission to delete this folder.');
+      return res.redirect('/dashboard');
+    }
+
+    await folderModel.deleteFolder(req.params.id);
+    req.flash('success', 'Folder deleted. Files moved to root.');
+    res.redirect('/dashboard');
+  } catch (err) {
+    next(err);
+  }
+};
+
+const viewFolder = async (req, res, next) => {
+  try {
+    const folder = await folderModel.getFolderById(req.params.id);
+
+    if (!folder) {
+      req.flash('error', 'Folder not found.');
+      return res.redirect('/dashboard');
+    }
+
+    if (folder.userId !== req.user.id) {
+      req.flash('error', 'You do not have permission to view this folder.');
+      return res.redirect('/dashboard');
+    }
+
+    const [files, allFolders] = await Promise.all([
+      fileModel.getFilesInFolder(req.params.id),
+      folderModel.getFoldersByUser(req.user.id),
+    ]);
+
+    res.render('folder', {
+      user: req.user,
+      folder,
+      files,
+      allFolders,
+      messages: res.locals.messages,
+    });
+  } catch (err) {
+    next(err);
+  }
+};
+
+module.exports = { createFolder, renameFolder, deleteFolder, viewFolder };

--- a/src/models/fileModel.js
+++ b/src/models/fileModel.js
@@ -1,8 +1,8 @@
 const prisma = require('../config/prisma');
 
-const createFile = async ({ name, type, size, url, userId }) => {
+const createFile = async ({ name, type, size, url, userId, folderId }) => {
   return prisma.file.create({
-    data: { name, type, size, url, userId },
+    data: { name, type, size, url, userId, folderId: folderId || null },
   });
 };
 

--- a/src/models/fileModel.js
+++ b/src/models/fileModel.js
@@ -21,4 +21,22 @@ const deleteFile = async (id) => {
   return prisma.file.delete({ where: { id } });
 };
 
-module.exports = { createFile, getFilesByUser, getFileById, deleteFile };
+const getRootFiles = async (userId) => {
+  return prisma.file.findMany({
+    where: { userId, folderId: null },
+    orderBy: { createdAt: 'desc' },
+  });
+};
+
+const getFilesInFolder = async (folderId) => {
+  return prisma.file.findMany({
+    where: { folderId },
+    orderBy: { createdAt: 'desc' },
+  });
+};
+
+const moveFile = async (id, folderId) => {
+  return prisma.file.update({ where: { id }, data: { folderId: folderId || null } });
+};
+
+module.exports = { createFile, getFilesByUser, getFileById, deleteFile, getRootFiles, getFilesInFolder, moveFile };

--- a/src/models/folderModel.js
+++ b/src/models/folderModel.js
@@ -1,0 +1,30 @@
+const prisma = require('../config/prisma');
+
+const createFolder = async ({ name, userId }) => {
+  return prisma.folder.create({
+    data: { name, userId },
+  });
+};
+
+const getFoldersByUser = async (userId) => {
+  return prisma.folder.findMany({
+    where: { userId },
+    orderBy: { createdAt: 'asc' },
+    include: { _count: { select: { files: true } } },
+  });
+};
+
+const getFolderById = async (id) => {
+  return prisma.folder.findUnique({ where: { id } });
+};
+
+const updateFolder = async (id, { name }) => {
+  return prisma.folder.update({ where: { id }, data: { name } });
+};
+
+const deleteFolder = async (id) => {
+  await prisma.file.updateMany({ where: { folderId: id }, data: { folderId: null } });
+  return prisma.folder.delete({ where: { id } });
+};
+
+module.exports = { createFolder, getFoldersByUser, getFolderById, updateFolder, deleteFolder };

--- a/src/models/folderModel.js
+++ b/src/models/folderModel.js
@@ -15,7 +15,12 @@ const getFoldersByUser = async (userId) => {
 };
 
 const getFolderById = async (id) => {
-  return prisma.folder.findUnique({ where: { id } });
+  try {
+    return await prisma.folder.findUnique({ where: { id } });
+  } catch (err) {
+    if (err.constructor.name === 'PrismaClientValidationError') return null;
+    throw err;
+  }
 };
 
 const updateFolder = async (id, { name }) => {

--- a/src/routes/fileRoutes.js
+++ b/src/routes/fileRoutes.js
@@ -22,5 +22,6 @@ const handleUpload = (req, res, next) => {
 router.get('/dashboard', isAuthenticated, fileController.getFiles);
 router.post('/files/upload', isAuthenticated, handleUpload, fileController.uploadFile);
 router.post('/files/:id/delete', isAuthenticated, fileController.deleteFile);
+router.post('/files/:id/move', isAuthenticated, fileController.moveFile);
 
 module.exports = router;

--- a/src/routes/folderRoutes.js
+++ b/src/routes/folderRoutes.js
@@ -1,0 +1,12 @@
+const express = require('express');
+const isAuthenticated = require('../middleware/isAuthenticated');
+const folderController = require('../controllers/folderController');
+
+const router = express.Router();
+
+router.get('/folders/:id', isAuthenticated, folderController.viewFolder);
+router.post('/folders', isAuthenticated, folderController.createFolder);
+router.post('/folders/:id/rename', isAuthenticated, folderController.renameFolder);
+router.post('/folders/:id/delete', isAuthenticated, folderController.deleteFolder);
+
+module.exports = router;

--- a/src/views/dashboard.ejs
+++ b/src/views/dashboard.ejs
@@ -15,43 +15,191 @@
     <p style="color: green;"><%= messages.success[0] %></p>
   <% } %>
 
-  <h2>Upload a File</h2>
-  <form action="/files/upload" method="POST" enctype="multipart/form-data">
-    <input type="file" name="file" required />
-    <button type="submit">Upload</button>
-  </form>
+  <p>
+    <% if (viewMode === 'folder') { %>
+      Folder View | <a href="?view=flat">Flat View</a>
+    <% } else { %>
+      <a href="/dashboard">Folder View</a> | Flat View
+    <% } %>
+  </p>
 
-  <h2>Your Files</h2>
-  <% if (files && files.length > 0) { %>
-    <table>
-      <thead>
-        <tr>
-          <th>Name</th>
-          <th>Type</th>
-          <th>Size</th>
-          <th>Uploaded</th>
-          <th>Actions</th>
-        </tr>
-      </thead>
-      <tbody>
-        <% files.forEach(function(file) { %>
+  <% if (viewMode === 'folder') { %>
+
+    <h2>Folders</h2>
+    <form action="/folders" method="POST" style="margin-bottom: 1em;">
+      <input type="text" name="name" placeholder="New folder name" required />
+      <button type="submit">Create Folder</button>
+    </form>
+
+    <% if (folders && folders.length > 0) { %>
+      <table>
+        <thead>
           <tr>
-            <td><%= file.name %></td>
-            <td><%= file.type %></td>
-            <td><%= (file.size / 1024).toFixed(1) %> KB</td>
-            <td><%= new Date(file.createdAt).toLocaleDateString() %></td>
-            <td>
-              <a href="<%= file.url %>" target="_blank">Download</a>
-              <form action="/files/<%= file.id %>/delete" method="POST" style="display:inline;">
-                <button type="submit">Delete</button>
-              </form>
-            </td>
+            <th>Name</th>
+            <th>Files</th>
+            <th>Actions</th>
           </tr>
-        <% }); %>
-      </tbody>
-    </table>
+        </thead>
+        <tbody>
+          <% folders.forEach(function(folder) { %>
+            <tr>
+              <td><%= folder.name %></td>
+              <td><%= folder._count.files %></td>
+              <td>
+                <a href="/folders/<%= folder.id %>">View</a>
+                <form action="/folders/<%= folder.id %>/rename" method="POST" style="display:inline;">
+                  <input type="text" name="name" value="<%= folder.name %>" required />
+                  <button type="submit">Rename</button>
+                </form>
+                <form action="/folders/<%= folder.id %>/delete" method="POST" style="display:inline;">
+                  <button type="submit">Delete</button>
+                </form>
+              </td>
+            </tr>
+          <% }); %>
+        </tbody>
+      </table>
+    <% } else { %>
+      <p>No folders yet.</p>
+    <% } %>
+
+    <h2>Upload a File</h2>
+    <form action="/files/upload" method="POST" enctype="multipart/form-data">
+      <input type="file" name="file" required />
+      <select name="folderId">
+        <option value="">No folder</option>
+        <% if (folders) { folders.forEach(function(folder) { %>
+          <option value="<%= folder.id %>"><%= folder.name %></option>
+        <% }); } %>
+      </select>
+      <button type="submit">Upload</button>
+    </form>
+
+    <h2>Uncategorized Files</h2>
+    <% if (rootFiles && rootFiles.length > 0) { %>
+      <table>
+        <thead>
+          <tr>
+            <th>Name</th>
+            <th>Type</th>
+            <th>Size</th>
+            <th>Uploaded</th>
+            <th>Actions</th>
+          </tr>
+        </thead>
+        <tbody>
+          <% rootFiles.forEach(function(file) { %>
+            <tr>
+              <td><%= file.name %></td>
+              <td><%= file.type %></td>
+              <td><%= (file.size / 1024).toFixed(1) %> KB</td>
+              <td><%= new Date(file.createdAt).toLocaleDateString() %></td>
+              <td>
+                <a href="<%= file.url %>" target="_blank">Download</a>
+                <form action="/files/<%= file.id %>/move" method="POST" style="display:inline;">
+                  <select name="folderId">
+                    <option value="">Root</option>
+                    <% if (folders) { folders.forEach(function(folder) { %>
+                      <option value="<%= folder.id %>"><%= folder.name %></option>
+                    <% }); } %>
+                  </select>
+                  <button type="submit">Move</button>
+                </form>
+                <form action="/files/<%= file.id %>/delete" method="POST" style="display:inline;">
+                  <button type="submit">Delete</button>
+                </form>
+              </td>
+            </tr>
+          <% }); %>
+        </tbody>
+      </table>
+    <% } else { %>
+      <p>No uncategorized files.</p>
+    <% } %>
+
   <% } else { %>
-    <p>You have not uploaded any files yet.</p>
+
+    <h2>Upload a File</h2>
+    <form action="/files/upload" method="POST" enctype="multipart/form-data">
+      <input type="file" name="file" required />
+      <select name="folderId">
+        <option value="">No folder</option>
+        <% if (folders) { folders.forEach(function(folder) { %>
+          <option value="<%= folder.id %>"><%= folder.name %></option>
+        <% }); } %>
+      </select>
+      <button type="submit">Upload</button>
+    </form>
+
+    <h2>All Files</h2>
+    <pre style="background: #f4f4f4; padding: 1em; font-family: monospace;">
+<% if (folders) { folders.forEach(function(folder) { %>
+📁 <%= folder.name %> (<%= folder._count.files %> files)
+<% const folderFiles = files ? files.filter(function(f) { return f.folderId === folder.id; }) : []; %>
+<% folderFiles.forEach(function(file) { %>
+  • <%= file.name %>  <%= (file.size / 1024).toFixed(1) %> KB  <%= new Date(file.createdAt).toLocaleDateString() %>
+<% }); %>
+<% if (folderFiles.length === 0) { %>
+  (empty)
+<% } %>
+
+<% }); } %>
+📁 Root
+<% const rootFilesList = files ? files.filter(function(f) { return !f.folderId; }) : []; %>
+<% rootFilesList.forEach(function(file) { %>
+  • <%= file.name %>  <%= (file.size / 1024).toFixed(1) %> KB  <%= new Date(file.createdAt).toLocaleDateString() %>
+<% }); %>
+<% if (rootFilesList.length === 0) { %>
+  (empty)
+<% } %>
+    </pre>
+
+    <% if (files && files.length > 0) { %>
+      <table>
+        <thead>
+          <tr>
+            <th>Name</th>
+            <th>Type</th>
+            <th>Size</th>
+            <th>Uploaded</th>
+            <th>Folder</th>
+            <th>Actions</th>
+          </tr>
+        </thead>
+        <tbody>
+          <% files.forEach(function(file) { %>
+            <tr>
+              <td><%= file.name %></td>
+              <td><%= file.type %></td>
+              <td><%= (file.size / 1024).toFixed(1) %> KB</td>
+              <td><%= new Date(file.createdAt).toLocaleDateString() %></td>
+              <td>
+                <% const fileFolder = folders ? folders.find(function(fd) { return fd.id === file.folderId; }) : null; %>
+                <%= fileFolder ? fileFolder.name : 'Root' %>
+              </td>
+              <td>
+                <a href="<%= file.url %>" target="_blank">Download</a>
+                <form action="/files/<%= file.id %>/move" method="POST" style="display:inline;">
+                  <select name="folderId">
+                    <option value="">Root</option>
+                    <% if (folders) { folders.forEach(function(folder) { %>
+                      <option value="<%= folder.id %>" <%= file.folderId === folder.id ? 'selected' : '' %>><%= folder.name %></option>
+                    <% }); } %>
+                  </select>
+                  <button type="submit">Move</button>
+                </form>
+                <form action="/files/<%= file.id %>/delete" method="POST" style="display:inline;">
+                  <button type="submit">Delete</button>
+                </form>
+              </td>
+            </tr>
+          <% }); %>
+        </tbody>
+      </table>
+    <% } else { %>
+      <p>You have not uploaded any files yet.</p>
+    <% } %>
+
   <% } %>
 
   <form action="/logout" method="POST">

--- a/src/views/folder.ejs
+++ b/src/views/folder.ejs
@@ -1,0 +1,78 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title><%= folder.name %> - File Uploader</title>
+</head>
+<body>
+  <p><a href="/dashboard">&lt; Back to Dashboard</a></p>
+
+  <h1><%= folder.name %></h1>
+
+  <% if (messages && messages.error && messages.error.length > 0) { %>
+    <p style="color: red;"><%= messages.error[0] %></p>
+  <% } %>
+  <% if (messages && messages.success && messages.success.length > 0) { %>
+    <p style="color: green;"><%= messages.success[0] %></p>
+  <% } %>
+
+  <h2>Upload a File</h2>
+  <form action="/files/upload" method="POST" enctype="multipart/form-data">
+    <input type="file" name="file" required />
+    <select name="folderId">
+      <option value="">No folder</option>
+      <% if (allFolders) { allFolders.forEach(function(f) { %>
+        <option value="<%= f.id %>" <%= f.id === folder.id ? 'selected' : '' %>><%= f.name %></option>
+      <% }); } %>
+    </select>
+    <button type="submit">Upload</button>
+  </form>
+
+  <h2>Files</h2>
+  <% if (files && files.length > 0) { %>
+    <table>
+      <thead>
+        <tr>
+          <th>Name</th>
+          <th>Type</th>
+          <th>Size</th>
+          <th>Uploaded</th>
+          <th>Actions</th>
+        </tr>
+      </thead>
+      <tbody>
+        <% files.forEach(function(file) { %>
+          <tr>
+            <td><%= file.name %></td>
+            <td><%= file.type %></td>
+            <td><%= (file.size / 1024).toFixed(1) %> KB</td>
+            <td><%= new Date(file.createdAt).toLocaleDateString() %></td>
+            <td>
+              <a href="<%= file.url %>" target="_blank">Download</a>
+              <form action="/files/<%= file.id %>/move" method="POST" style="display:inline;">
+                <select name="folderId">
+                  <option value="">Root</option>
+                  <% if (allFolders) { allFolders.forEach(function(fd) { %>
+                    <option value="<%= fd.id %>" <%= file.folderId === fd.id ? 'selected' : '' %>><%= fd.name %></option>
+                  <% }); } %>
+                </select>
+                <button type="submit">Move</button>
+              </form>
+              <form action="/files/<%= file.id %>/delete" method="POST" style="display:inline;">
+                <button type="submit">Delete</button>
+              </form>
+            </td>
+          </tr>
+        <% }); %>
+      </tbody>
+    </table>
+  <% } else { %>
+    <p>This folder is empty.</p>
+  <% } %>
+
+  <form action="/logout" method="POST">
+    <button type="submit">Log Out</button>
+  </form>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- Full folder CRUD: create, rename (inline on dashboard), delete (unassigns files to root)
- File-folder association: assign folder at upload time, move existing files to any folder
- Dashboard folder view (default) and flat/tree view (`?view=flat`)
- Folder detail view (`/folders/:id`) with upload, move, and delete
- 15 new folder tests; all 41 tests passing

## Test plan
- [ ] `npm test` — all 41 tests pass
- [ ] Create a folder, upload a file into it, view folder detail page
- [ ] Move a file between folders and to root
- [ ] Rename a folder inline on the dashboard
- [ ] Delete a folder — verify its files move to uncategorized
- [ ] Toggle flat view — confirm markdown-style tree groups files by folder
- [ ] Smoke test on Railway after merge to main

🤖 Generated with [Claude Code](https://claude.com/claude-code)