### PR TITLE
fix(404): redirect on unknown routes instead of returning JSON

### DIFF
--- a/__tests__/app.test.js
+++ b/__tests__/app.test.js
@@ -8,8 +8,45 @@ jest.mock('connect-pg-simple', () => {
 });
 
 jest.mock('../src/models/userModel');
+jest.mock('../src/models/fileModel');
+jest.mock('../src/models/folderModel');
+jest.mock('../src/config/supabase', () => ({
+  storage: {
+    from: jest.fn(() => ({
+      upload: jest.fn().mockResolvedValue({ data: {}, error: null }),
+      getPublicUrl: jest.fn().mockReturnValue({ data: { publicUrl: 'https://test.supabase.co/...' } }),
+      remove: jest.fn().mockResolvedValue({ data: {}, error: null }),
+    })),
+  },
+}));
 
+const userModel = require('../src/models/userModel');
+const fileModel = require('../src/models/fileModel');
+const folderModel = require('../src/models/folderModel');
 const app = require('../src/app');
+
+const FAKE_USER = {
+  id: 'uuid-test-1',
+  email: 'test@example.com',
+  password: '$2b$12$hashedpassword',
+  name: 'Test User',
+};
+
+const loginAgent = async () => {
+  const bcrypt = require('bcrypt');
+  const hashedPassword = await bcrypt.hash('password123', 1);
+  userModel.findByEmail.mockResolvedValue({ ...FAKE_USER, password: hashedPassword });
+  userModel.findById.mockResolvedValue(FAKE_USER);
+  const agent = request.agent(app);
+  await agent.post('/login').send({ email: 'test@example.com', password: 'password123' });
+  return agent;
+};
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  fileModel.getFilesByUser.mockResolvedValue([]);
+  folderModel.getFoldersByUser.mockResolvedValue([]);
+});
 
 describe('API Endpoints', () => {
   test('GET / redirects to /login', async () => {
@@ -23,10 +60,19 @@ describe('API Endpoints', () => {
     expect(res.status).toBe(200);
     expect(res.body).toEqual({ message: 'API is working!' });
   });
+});
 
-  test('GET /nonexistent should return 404', async () => {
+describe('404 handler', () => {
+  test('unauthenticated user hitting unknown route redirects to /login', async () => {
     const res = await request(app).get('/nonexistent');
-    expect(res.status).toBe(404);
-    expect(res.body).toEqual({ error: 'Not Found' });
+    expect(res.status).toBe(302);
+    expect(res.headers.location).toBe('/login');
+  });
+
+  test('authenticated user hitting unknown route redirects to /dashboard', async () => {
+    const agent = await loginAgent();
+    const res = await agent.get('/nonexistent');
+    expect(res.status).toBe(302);
+    expect(res.headers.location).toBe('/dashboard');
   });
 });

--- a/src/app.js
+++ b/src/app.js
@@ -52,8 +52,12 @@ app.get('/', (_req, res) => {
   res.redirect('/login');
 });
 
-app.use((_req, res) => {
-  res.status(404).json({ error: 'Not Found' });
+app.use((req, res) => {
+  if (req.isAuthenticated()) {
+    req.flash('error', `Page not found: ${req.path}`);
+    return res.redirect('/dashboard');
+  }
+  res.redirect('/login');
 });
 
 app.use((err, _req, res, _next) => {


### PR DESCRIPTION
## Summary
- Authenticated users hitting an unknown route now get a flash error and redirect to `/dashboard`
- Unauthenticated users redirect to `/login`
- Update `app.test.js` to cover both cases and add missing mocks (42 tests total)

🤖 Generated with [Claude Code](https://claude.com/claude-code)