### PR TITLE
feat(security): authenticated download route with signed URLs

### DIFF
--- a/__tests__/auth.test.js
+++ b/__tests__/auth.test.js
@@ -16,6 +16,7 @@ jest.mock('../src/config/supabase', () => ({
       upload: jest.fn().mockResolvedValue({ data: {}, error: null }),
       getPublicUrl: jest.fn().mockReturnValue({ data: { publicUrl: 'https://test.supabase.co/...' } }),
       remove: jest.fn().mockResolvedValue({ data: {}, error: null }),
+      createSignedUrl: jest.fn().mockResolvedValue({ data: { signedUrl: 'https://test.supabase.co/signed/test' }, error: null }),
     })),
   },
 }));

--- a/__tests__/file.test.js
+++ b/__tests__/file.test.js
@@ -16,6 +16,7 @@ jest.mock('../src/config/supabase', () => ({
       upload: jest.fn().mockResolvedValue({ data: {}, error: null }),
       getPublicUrl: jest.fn().mockReturnValue({ data: { publicUrl: 'https://test.supabase.co/object/public/test-bucket/user-id/test-file.txt' } }),
       remove: jest.fn().mockResolvedValue({ data: {}, error: null }),
+      createSignedUrl: jest.fn().mockResolvedValue({ data: { signedUrl: 'https://test.supabase.co/signed/test-file.txt' }, error: null }),
     })),
   },
 }));
@@ -167,5 +168,40 @@ describe('POST /files/:id/delete', () => {
     expect(res.status).toBe(302);
     expect(res.headers.location).toBe('/dashboard');
     expect(fileModel.deleteFile).not.toHaveBeenCalled();
+  });
+});
+
+describe('GET /files/:id/download', () => {
+  test('redirects unauthenticated users to /login', async () => {
+    const res = await request(app).get(`/files/${FAKE_FILE.id}/download`);
+    expect(res.status).toBe(302);
+    expect(res.headers.location).toBe('/login');
+  });
+
+  test('redirects to signed URL for file owner', async () => {
+    fileModel.getFileById.mockResolvedValue(FAKE_FILE);
+    const agent = await loginAgent();
+
+    const res = await agent.get(`/files/${FAKE_FILE.id}/download`);
+    expect(res.status).toBe(302);
+    expect(res.headers.location).toBe('https://test.supabase.co/signed/test-file.txt');
+  });
+
+  test('flashes error when file not found', async () => {
+    fileModel.getFileById.mockResolvedValue(null);
+    const agent = await loginAgent();
+
+    const res = await agent.get('/files/nonexistent-id/download');
+    expect(res.status).toBe(302);
+    expect(res.headers.location).toBe('/dashboard');
+  });
+
+  test('flashes error when user does not own file', async () => {
+    fileModel.getFileById.mockResolvedValue({ ...FAKE_FILE, userId: 'other-user-id' });
+    const agent = await loginAgent();
+
+    const res = await agent.get(`/files/${FAKE_FILE.id}/download`);
+    expect(res.status).toBe(302);
+    expect(res.headers.location).toBe('/dashboard');
   });
 });

--- a/src/controllers/fileController.js
+++ b/src/controllers/fileController.js
@@ -116,4 +116,35 @@ const moveFile = async (req, res, next) => {
   }
 };
 
-module.exports = { getFiles, uploadFile, deleteFile, moveFile };
+const downloadFile = async (req, res, next) => {
+  try {
+    const file = await fileModel.getFileById(req.params.id);
+
+    if (!file) {
+      req.flash('error', 'File not found.');
+      return res.redirect('/dashboard');
+    }
+
+    if (file.userId !== req.user.id) {
+      req.flash('error', 'You do not have permission to download this file.');
+      return res.redirect('/dashboard');
+    }
+
+    const parsedUrl = new URL(file.url);
+    const storagePath = parsedUrl.pathname.split(`/object/public/${BUCKET}/`)[1];
+
+    const { data, error: signError } = await supabase.storage
+      .from(BUCKET)
+      .createSignedUrl(storagePath, 60);
+
+    if (signError) {
+      return next(signError);
+    }
+
+    res.redirect(data.signedUrl);
+  } catch (err) {
+    next(err);
+  }
+};
+
+module.exports = { getFiles, uploadFile, deleteFile, moveFile, downloadFile };

--- a/src/routes/fileRoutes.js
+++ b/src/routes/fileRoutes.js
@@ -20,6 +20,7 @@ const handleUpload = (req, res, next) => {
 };
 
 router.get('/dashboard', isAuthenticated, fileController.getFiles);
+router.get('/files/:id/download', isAuthenticated, fileController.downloadFile);
 router.post('/files/upload', isAuthenticated, handleUpload, fileController.uploadFile);
 router.post('/files/:id/delete', isAuthenticated, fileController.deleteFile);
 router.post('/files/:id/move', isAuthenticated, fileController.moveFile);

--- a/src/views/dashboard.ejs
+++ b/src/views/dashboard.ejs
@@ -114,7 +114,7 @@
                   <td style="color: var(--muted);"><%= new Date(file.createdAt).toLocaleDateString() %></td>
                   <td>
                     <div class="td-actions">
-                      <a href="<%= file.url %>" target="_blank" class="btn btn--ghost btn--sm">Download</a>
+                      <a href="/files/<%= file.id %>/download" class="btn btn--ghost btn--sm">Download</a>
                       <form action="/files/<%= file.id %>/move" method="POST" class="form-row" style="gap:0.3rem;">
                         <select name="folderId" style="font-size:0.78rem; padding: 0.25rem 0.4rem;">
                           <option value="">Root</option>
@@ -200,7 +200,7 @@
                   </td>
                   <td>
                     <div class="td-actions">
-                      <a href="<%= file.url %>" target="_blank" class="btn btn--ghost btn--sm">Download</a>
+                      <a href="/files/<%= file.id %>/download" class="btn btn--ghost btn--sm">Download</a>
                       <form action="/files/<%= file.id %>/move" method="POST" class="form-row" style="gap:0.3rem;">
                         <select name="folderId" style="font-size:0.78rem; padding: 0.25rem 0.4rem;">
                           <option value="">Root</option>

--- a/src/views/folder.ejs
+++ b/src/views/folder.ejs
@@ -62,7 +62,7 @@
                 <td style="color: var(--muted);"><%= new Date(file.createdAt).toLocaleDateString() %></td>
                 <td>
                   <div class="td-actions">
-                    <a href="<%= file.url %>" target="_blank" class="btn btn--ghost btn--sm">Download</a>
+                    <a href="/files/<%= file.id %>/download" class="btn btn--ghost btn--sm">Download</a>
                     <form action="/files/<%= file.id %>/move" method="POST" class="form-row" style="gap:0.3rem;">
                       <select name="folderId" style="font-size:0.78rem; padding: 0.25rem 0.4rem;">
                         <option value="">Root</option>


### PR DESCRIPTION
## Summary
- Add `GET /files/:id/download` that verifies ownership and redirects to a 60-second Supabase signed URL
- All Download links in dashboard and folder views now route through this endpoint instead of exposing the raw public URL
- 4 new download tests (46 total)

## Note
To fully enforce storage-level access control, set the Supabase bucket to **private** in the Supabase console. The signed URL approach works with both public and private buckets.

🤖 Generated with [Claude Code](https://claude.com/claude-code)