### PR TITLE
feat(preview): inline file preview for images, PDFs, video, and audio

### DIFF
--- a/__tests__/file.test.js
+++ b/__tests__/file.test.js
@@ -205,3 +205,38 @@ describe('GET /files/:id/download', () => {
     expect(res.headers.location).toBe('/dashboard');
   });
 });
+
+describe('GET /files/:id/preview', () => {
+  test('redirects unauthenticated users to /login', async () => {
+    const res = await request(app).get(`/files/${FAKE_FILE.id}/preview`);
+    expect(res.status).toBe(302);
+    expect(res.headers.location).toBe('/login');
+  });
+
+  test('renders preview page for file owner', async () => {
+    fileModel.getFileById.mockResolvedValue(FAKE_FILE);
+    const agent = await loginAgent();
+
+    const res = await agent.get(`/files/${FAKE_FILE.id}/preview`);
+    expect(res.status).toBe(200);
+    expect(res.text).toContain(FAKE_FILE.name);
+  });
+
+  test('flashes error when file not found', async () => {
+    fileModel.getFileById.mockResolvedValue(null);
+    const agent = await loginAgent();
+
+    const res = await agent.get('/files/nonexistent-id/preview');
+    expect(res.status).toBe(302);
+    expect(res.headers.location).toBe('/dashboard');
+  });
+
+  test('flashes error when user does not own file', async () => {
+    fileModel.getFileById.mockResolvedValue({ ...FAKE_FILE, userId: 'other-user-id' });
+    const agent = await loginAgent();
+
+    const res = await agent.get(`/files/${FAKE_FILE.id}/preview`);
+    expect(res.status).toBe(302);
+    expect(res.headers.location).toBe('/dashboard');
+  });
+});

--- a/src/controllers/fileController.js
+++ b/src/controllers/fileController.js
@@ -116,6 +116,37 @@ const moveFile = async (req, res, next) => {
   }
 };
 
+const previewFile = async (req, res, next) => {
+  try {
+    const file = await fileModel.getFileById(req.params.id);
+
+    if (!file) {
+      req.flash('error', 'File not found.');
+      return res.redirect('/dashboard');
+    }
+
+    if (file.userId !== req.user.id) {
+      req.flash('error', 'You do not have permission to preview this file.');
+      return res.redirect('/dashboard');
+    }
+
+    const parsedUrl = new URL(file.url);
+    const storagePath = parsedUrl.pathname.split(`/object/public/${BUCKET}/`)[1];
+
+    const { data, error: signError } = await supabase.storage
+      .from(BUCKET)
+      .createSignedUrl(storagePath, 300);
+
+    if (signError) {
+      return next(signError);
+    }
+
+    res.render('preview', { user: req.user, file, signedUrl: data.signedUrl });
+  } catch (err) {
+    next(err);
+  }
+};
+
 const downloadFile = async (req, res, next) => {
   try {
     const file = await fileModel.getFileById(req.params.id);
@@ -147,4 +178,4 @@ const downloadFile = async (req, res, next) => {
   }
 };
 
-module.exports = { getFiles, uploadFile, deleteFile, moveFile, downloadFile };
+module.exports = { getFiles, uploadFile, deleteFile, moveFile, downloadFile, previewFile };

--- a/src/routes/fileRoutes.js
+++ b/src/routes/fileRoutes.js
@@ -20,6 +20,7 @@ const handleUpload = (req, res, next) => {
 };
 
 router.get('/dashboard', isAuthenticated, fileController.getFiles);
+router.get('/files/:id/preview', isAuthenticated, fileController.previewFile);
 router.get('/files/:id/download', isAuthenticated, fileController.downloadFile);
 router.post('/files/upload', isAuthenticated, handleUpload, fileController.uploadFile);
 router.post('/files/:id/delete', isAuthenticated, fileController.deleteFile);

--- a/src/views/dashboard.ejs
+++ b/src/views/dashboard.ejs
@@ -114,6 +114,7 @@
                   <td style="color: var(--muted);"><%= new Date(file.createdAt).toLocaleDateString() %></td>
                   <td>
                     <div class="td-actions">
+                      <a href="/files/<%= file.id %>/preview" class="btn btn--ghost btn--sm">Preview</a>
                       <a href="/files/<%= file.id %>/download" class="btn btn--ghost btn--sm">Download</a>
                       <form action="/files/<%= file.id %>/move" method="POST" class="form-row" style="gap:0.3rem;">
                         <select name="folderId" style="font-size:0.78rem; padding: 0.25rem 0.4rem;">
@@ -200,6 +201,7 @@
                   </td>
                   <td>
                     <div class="td-actions">
+                      <a href="/files/<%= file.id %>/preview" class="btn btn--ghost btn--sm">Preview</a>
                       <a href="/files/<%= file.id %>/download" class="btn btn--ghost btn--sm">Download</a>
                       <form action="/files/<%= file.id %>/move" method="POST" class="form-row" style="gap:0.3rem;">
                         <select name="folderId" style="font-size:0.78rem; padding: 0.25rem 0.4rem;">

--- a/src/views/folder.ejs
+++ b/src/views/folder.ejs
@@ -62,7 +62,8 @@
                 <td style="color: var(--muted);"><%= new Date(file.createdAt).toLocaleDateString() %></td>
                 <td>
                   <div class="td-actions">
-                    <a href="/files/<%= file.id %>/download" class="btn btn--ghost btn--sm">Download</a>
+                    <a href="/files/<%= file.id %>/preview" class="btn btn--ghost btn--sm">Preview</a>
+                      <a href="/files/<%= file.id %>/download" class="btn btn--ghost btn--sm">Download</a>
                     <form action="/files/<%= file.id %>/move" method="POST" class="form-row" style="gap:0.3rem;">
                       <select name="folderId" style="font-size:0.78rem; padding: 0.25rem 0.4rem;">
                         <option value="">Root</option>

--- a/src/views/preview.ejs
+++ b/src/views/preview.ejs
@@ -1,0 +1,98 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title><%= file.name %> - Preview</title>
+  <link rel="stylesheet" href="/style.css" />
+  <style>
+    .preview-frame {
+      width: 100%;
+      border: 1px solid var(--border);
+      border-radius: var(--radius);
+      background: #000;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      overflow: hidden;
+    }
+    .preview-frame img {
+      max-width: 100%;
+      max-height: 70vh;
+      object-fit: contain;
+      display: block;
+      margin: 0 auto;
+      background: #1a1a1a;
+    }
+    .preview-frame iframe,
+    .preview-frame video {
+      width: 100%;
+      height: 70vh;
+      border: none;
+      display: block;
+    }
+    .preview-frame .no-preview {
+      padding: 3rem;
+      text-align: center;
+      color: var(--muted);
+      background: var(--bg);
+      width: 100%;
+    }
+    .preview-frame .no-preview p { margin: 0 0 1rem; font-size: 2rem; }
+  </style>
+</head>
+<body>
+  <div class="page-wrap">
+
+    <div class="topbar">
+      <h1><%= file.name %></h1>
+      <div class="topbar-actions">
+        <a href="/dashboard" class="btn btn--ghost btn--sm">&larr; Dashboard</a>
+        <a href="/files/<%= file.id %>/download" class="btn btn--primary btn--sm">Download</a>
+        <form action="/logout" method="POST" style="margin:0;">
+          <button type="submit" class="btn--logout">Log out</button>
+        </form>
+      </div>
+    </div>
+
+    <div class="card" style="padding: 0.75rem;">
+      <div style="margin-bottom: 0.75rem; font-size: 0.8rem; color: var(--muted);">
+        <%= file.type %> &nbsp;·&nbsp;
+        <%= (file.size / 1024).toFixed(1) %> KB &nbsp;·&nbsp;
+        Uploaded <%= new Date(file.createdAt).toLocaleDateString() %>
+      </div>
+
+      <div class="preview-frame">
+        <% if (file.type.startsWith('image/')) { %>
+          <img src="<%= signedUrl %>" alt="<%= file.name %>" />
+
+        <% } else if (file.type === 'application/pdf') { %>
+          <iframe src="<%= signedUrl %>" title="<%= file.name %>"></iframe>
+
+        <% } else if (file.type.startsWith('video/')) { %>
+          <video controls>
+            <source src="<%= signedUrl %>" type="<%= file.type %>" />
+            Your browser does not support the video tag.
+          </video>
+
+        <% } else if (file.type.startsWith('audio/')) { %>
+          <div class="no-preview" style="background: var(--surface);">
+            <p>🎵</p>
+            <audio controls style="width:100%; max-width:400px;">
+              <source src="<%= signedUrl %>" type="<%= file.type %>" />
+            </audio>
+          </div>
+
+        <% } else { %>
+          <div class="no-preview">
+            <p>📄</p>
+            <p style="font-size:0.9rem; margin-bottom:0;">Preview not available for <strong><%= file.type %></strong></p>
+            <p style="font-size:0.85rem; margin-top:0.5rem;"><a href="/files/<%= file.id %>/download">Download the file</a> to open it.</p>
+          </div>
+        <% } %>
+      </div>
+    </div>
+
+  </div>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- New `GET /files/:id/preview` route with ownership check and 5-minute signed URL
- `preview.ejs` renders inline previews by MIME type: image, PDF, video, audio, or a fallback message
- Preview link added to file action rows in dashboard and folder views
- 4 new tests (50 total)

🤖 Generated with [Claude Code](https://claude.com/claude-code)