### PR TITLE
feat(pagination): server-side pagination for file listings

### DIFF
--- a/__tests__/auth.test.js
+++ b/__tests__/auth.test.js
@@ -37,6 +37,8 @@ const FAKE_USER = {
 beforeEach(() => {
   jest.clearAllMocks();
   fileModel.getFilesByUser.mockResolvedValue([]);
+  fileModel.getRootFiles.mockResolvedValue([]);
+  fileModel.countRootFiles.mockResolvedValue(0);
   folderModel.getFoldersByUser.mockResolvedValue([]);
 });
 

--- a/__tests__/file.test.js
+++ b/__tests__/file.test.js
@@ -58,6 +58,8 @@ const loginAgent = async () => {
 beforeEach(() => {
   jest.clearAllMocks();
   fileModel.getFilesByUser.mockResolvedValue([]);
+  fileModel.getRootFiles.mockResolvedValue([]);
+  fileModel.countRootFiles.mockResolvedValue(0);
   folderModel.getFoldersByUser.mockResolvedValue([]);
 });
 
@@ -68,15 +70,16 @@ describe('GET /dashboard', () => {
     expect(res.headers.location).toBe('/login');
   });
 
-  test('renders dashboard for authenticated users and calls getFilesByUser and getFoldersByUser', async () => {
-    fileModel.getFilesByUser.mockResolvedValue([FAKE_FILE]);
+  test('renders dashboard for authenticated users and calls getRootFiles and getFoldersByUser', async () => {
+    fileModel.getRootFiles.mockResolvedValue([FAKE_FILE]);
+    fileModel.countRootFiles.mockResolvedValue(1);
     folderModel.getFoldersByUser.mockResolvedValue([]);
     const agent = await loginAgent();
 
     const res = await agent.get('/dashboard');
     expect(res.status).toBe(200);
     expect(res.text).toContain('Welcome');
-    expect(fileModel.getFilesByUser).toHaveBeenCalledWith(FAKE_USER.id);
+    expect(fileModel.getRootFiles).toHaveBeenCalledWith(FAKE_USER.id, expect.objectContaining({ skip: 0, take: 20 }));
     expect(folderModel.getFoldersByUser).toHaveBeenCalledWith(FAKE_USER.id);
   });
 });

--- a/__tests__/folder.test.js
+++ b/__tests__/folder.test.js
@@ -67,20 +67,24 @@ const loginAgent = async () => {
 beforeEach(() => {
   jest.clearAllMocks();
   fileModel.getFilesByUser.mockResolvedValue([]);
+  fileModel.getRootFiles.mockResolvedValue([]);
+  fileModel.countRootFiles.mockResolvedValue(0);
   fileModel.getFilesInFolder.mockResolvedValue([]);
+  fileModel.countFilesInFolder.mockResolvedValue(0);
   folderModel.getFoldersByUser.mockResolvedValue([]);
 });
 
 describe('GET /dashboard', () => {
-  test('calls getFoldersByUser and getFilesByUser when authenticated', async () => {
+  test('calls getFoldersByUser and getRootFiles when authenticated', async () => {
     folderModel.getFoldersByUser.mockResolvedValue([FAKE_FOLDER]);
-    fileModel.getFilesByUser.mockResolvedValue([FAKE_FILE]);
+    fileModel.getRootFiles.mockResolvedValue([FAKE_FILE]);
+    fileModel.countRootFiles.mockResolvedValue(1);
     const agent = await loginAgent();
 
     const res = await agent.get('/dashboard');
     expect(res.status).toBe(200);
     expect(folderModel.getFoldersByUser).toHaveBeenCalledWith(FAKE_USER.id);
-    expect(fileModel.getFilesByUser).toHaveBeenCalledWith(FAKE_USER.id);
+    expect(fileModel.getRootFiles).toHaveBeenCalledWith(FAKE_USER.id, expect.objectContaining({ skip: 0 }));
   });
 
   test('GET /dashboard?view=flat returns 200', async () => {

--- a/public/style.css
+++ b/public/style.css
@@ -213,3 +213,28 @@ tr:hover td { background: var(--bg); }
 }
 .auth-card .btn { width: 100%; justify-content: center; padding: 0.6rem; }
 .auth-card p { font-size: 0.875rem; text-align: center; color: var(--muted); }
+
+/* Pagination */
+.pagination {
+  display: flex;
+  align-items: center;
+  gap: 0.4rem;
+  margin-top: 1rem;
+  font-size: 0.875rem;
+}
+.pagination a, .pagination span {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-width: 2rem;
+  height: 2rem;
+  padding: 0 0.5rem;
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  text-decoration: none;
+  color: var(--text);
+}
+.pagination a:hover { background: var(--bg); text-decoration: none; }
+.pagination .active { background: var(--primary); color: #fff; border-color: var(--primary); font-weight: 600; }
+.pagination .disabled { color: var(--muted); pointer-events: none; }
+.pagination-info { font-size: 0.8rem; color: var(--muted); margin-top: 0.4rem; }

--- a/src/controllers/fileController.js
+++ b/src/controllers/fileController.js
@@ -6,21 +6,32 @@ const folderModel = require('../models/folderModel');
 
 const BUCKET = process.env.SUPABASE_STORAGE_BUCKET;
 
+const PAGE_SIZE = 20;
+
 const getFiles = async (req, res, next) => {
   try {
-    const [folders, allFiles] = await Promise.all([
-      folderModel.getFoldersByUser(req.user.id),
-      fileModel.getFilesByUser(req.user.id),
-    ]);
-    const rootFiles = allFiles.filter((f) => !f.folderId);
     const viewMode = req.query.view === 'flat' ? 'flat' : 'folder';
-    res.render('dashboard', {
-      user: req.user,
-      folders,
-      files: allFiles,
-      rootFiles,
-      viewMode,
-    });
+    const page = Math.max(1, parseInt(req.query.page) || 1);
+    const skip = (page - 1) * PAGE_SIZE;
+
+    if (viewMode === 'flat') {
+      const [folders, allFiles] = await Promise.all([
+        folderModel.getFoldersByUser(req.user.id),
+        fileModel.getFilesByUser(req.user.id),
+      ]);
+      return res.render('dashboard', { user: req.user, folders, files: allFiles, rootFiles: [], viewMode, pagination: null, query: req.query });
+    }
+
+    const [folders, rootFiles, totalRootFiles] = await Promise.all([
+      folderModel.getFoldersByUser(req.user.id),
+      fileModel.getRootFiles(req.user.id, { skip, take: PAGE_SIZE }),
+      fileModel.countRootFiles(req.user.id),
+    ]);
+
+    const totalPages = Math.ceil(totalRootFiles / PAGE_SIZE);
+    const pagination = { page, totalPages, total: totalRootFiles, pageSize: PAGE_SIZE };
+
+    res.render('dashboard', { user: req.user, folders, files: [], rootFiles, viewMode, pagination, query: req.query });
   } catch (err) {
     next(err);
   }

--- a/src/controllers/folderController.js
+++ b/src/controllers/folderController.js
@@ -1,6 +1,8 @@
 const folderModel = require('../models/folderModel');
 const fileModel = require('../models/fileModel');
 
+const PAGE_SIZE = 20;
+
 const createFolder = async (req, res, next) => {
   const { name } = req.body;
 
@@ -82,16 +84,25 @@ const viewFolder = async (req, res, next) => {
       return res.redirect('/dashboard');
     }
 
-    const [files, allFolders] = await Promise.all([
-      fileModel.getFilesInFolder(req.params.id),
+    const page = Math.max(1, parseInt(req.query.page) || 1);
+    const skip = (page - 1) * PAGE_SIZE;
+
+    const [files, totalFiles, allFolders] = await Promise.all([
+      fileModel.getFilesInFolder(req.params.id, { skip, take: PAGE_SIZE }),
+      fileModel.countFilesInFolder(req.params.id),
       folderModel.getFoldersByUser(req.user.id),
     ]);
+
+    const totalPages = Math.ceil(totalFiles / PAGE_SIZE);
+    const pagination = { page, totalPages, total: totalFiles, pageSize: PAGE_SIZE };
 
     res.render('folder', {
       user: req.user,
       folder,
       files,
       allFolders,
+      pagination,
+      query: req.query,
     });
   } catch (err) {
     next(err);

--- a/src/models/fileModel.js
+++ b/src/models/fileModel.js
@@ -21,22 +21,34 @@ const deleteFile = async (id) => {
   return prisma.file.delete({ where: { id } });
 };
 
-const getRootFiles = async (userId) => {
+const getRootFiles = async (userId, { skip = 0, take } = {}) => {
   return prisma.file.findMany({
     where: { userId, folderId: null },
     orderBy: { createdAt: 'desc' },
+    skip,
+    ...(take !== undefined && { take }),
   });
 };
 
-const getFilesInFolder = async (folderId) => {
+const countRootFiles = async (userId) => {
+  return prisma.file.count({ where: { userId, folderId: null } });
+};
+
+const getFilesInFolder = async (folderId, { skip = 0, take } = {}) => {
   return prisma.file.findMany({
     where: { folderId },
     orderBy: { createdAt: 'desc' },
+    skip,
+    ...(take !== undefined && { take }),
   });
+};
+
+const countFilesInFolder = async (folderId) => {
+  return prisma.file.count({ where: { folderId } });
 };
 
 const moveFile = async (id, folderId) => {
   return prisma.file.update({ where: { id }, data: { folderId: folderId || null } });
 };
 
-module.exports = { createFile, getFilesByUser, getFileById, deleteFile, getRootFiles, getFilesInFolder, moveFile };
+module.exports = { createFile, getFilesByUser, getFileById, deleteFile, getRootFiles, countRootFiles, getFilesInFolder, countFilesInFolder, moveFile };

--- a/src/views/dashboard.ejs
+++ b/src/views/dashboard.ejs
@@ -137,6 +137,7 @@
         <% } else { %>
           <p class="empty-state">No uncategorized files.</p>
         <% } %>
+        <%- include('partials/pagination', { pagination, query }) %>
       </div>
 
     <% } else { %>

--- a/src/views/folder.ejs
+++ b/src/views/folder.ejs
@@ -85,6 +85,7 @@
       <% } else { %>
         <p class="empty-state">This folder is empty.</p>
       <% } %>
+      <%- include('partials/pagination', { pagination, query }) %>
     </div>
 
   </div>

--- a/src/views/partials/pagination.ejs
+++ b/src/views/partials/pagination.ejs
@@ -1,0 +1,27 @@
+<% if (pagination && pagination.totalPages > 1) { %>
+  <% const base = Object.assign({}, query); delete base.page; %>
+  <div class="pagination">
+    <% if (pagination.page > 1) { %>
+      <a href="?<%= new URLSearchParams(Object.assign({}, base, { page: pagination.page - 1 })).toString() %>">&laquo;</a>
+    <% } else { %>
+      <span class="disabled">&laquo;</span>
+    <% } %>
+
+    <% for (let p = 1; p <= pagination.totalPages; p++) { %>
+      <% if (p === pagination.page) { %>
+        <span class="active"><%= p %></span>
+      <% } else { %>
+        <a href="?<%= new URLSearchParams(Object.assign({}, base, { page: p })).toString() %>"><%= p %></a>
+      <% } %>
+    <% } %>
+
+    <% if (pagination.page < pagination.totalPages) { %>
+      <a href="?<%= new URLSearchParams(Object.assign({}, base, { page: pagination.page + 1 })).toString() %>">&raquo;</a>
+    <% } else { %>
+      <span class="disabled">&raquo;</span>
+    <% } %>
+  </div>
+  <p class="pagination-info">
+    Showing <%= (pagination.page - 1) * pagination.pageSize + 1 %>–<%= Math.min(pagination.page * pagination.pageSize, pagination.total) %> of <%= pagination.total %> files
+  </p>
+<% } %>


### PR DESCRIPTION
## Summary
- `fileModel` gains `countRootFiles` and `countFilesInFolder`; `getRootFiles`/`getFilesInFolder` accept `{ skip, take }`
- Dashboard folder view paginates uncategorized files at 20/page
- Folder detail view paginates files at 20/page
- `partials/pagination.ejs` renders prev/next/numbered links, preserving other query params
- Flat view remains unpaginated (tree summary)
- 50 tests passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)