### PR TITLE
feat(account): profile and password management

### DIFF
--- a/__tests__/account.test.js
+++ b/__tests__/account.test.js
@@ -1,0 +1,177 @@
+const request = require('supertest');
+
+jest.mock('connect-pg-simple', () => {
+  return () => {
+    const session = require('express-session');
+    return session.MemoryStore;
+  };
+});
+
+jest.mock('../src/models/userModel');
+jest.mock('../src/models/fileModel');
+jest.mock('../src/models/folderModel');
+jest.mock('../src/config/supabase', () => ({
+  storage: {
+    from: jest.fn(() => ({
+      upload: jest.fn().mockResolvedValue({ data: {}, error: null }),
+      getPublicUrl: jest.fn().mockReturnValue({ data: { publicUrl: 'https://test.supabase.co/...' } }),
+      remove: jest.fn().mockResolvedValue({ data: {}, error: null }),
+      createSignedUrl: jest.fn().mockResolvedValue({ data: { signedUrl: 'https://test.supabase.co/signed/test' }, error: null }),
+    })),
+  },
+}));
+
+const userModel = require('../src/models/userModel');
+const fileModel = require('../src/models/fileModel');
+const folderModel = require('../src/models/folderModel');
+const app = require('../src/app');
+
+const FAKE_USER = {
+  id: 'uuid-test-1',
+  email: 'test@example.com',
+  password: '$2b$12$hashedpassword',
+  name: 'Test User',
+};
+
+const loginAgent = async () => {
+  const bcrypt = require('bcrypt');
+  const hashedPassword = await bcrypt.hash('password123', 1);
+  userModel.findByEmail.mockResolvedValue({ ...FAKE_USER, password: hashedPassword });
+  userModel.findById.mockResolvedValue({ ...FAKE_USER, password: hashedPassword });
+  const agent = request.agent(app);
+  await agent.post('/login').send({ email: 'test@example.com', password: 'password123' });
+  return agent;
+};
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  fileModel.getFilesByUser.mockResolvedValue([]);
+  fileModel.getRootFiles.mockResolvedValue([]);
+  fileModel.countRootFiles.mockResolvedValue(0);
+  folderModel.getFoldersByUser.mockResolvedValue([]);
+});
+
+describe('GET /account', () => {
+  test('redirects unauthenticated users to /login', async () => {
+    const res = await request(app).get('/account');
+    expect(res.status).toBe(302);
+    expect(res.headers.location).toBe('/login');
+  });
+
+  test('renders account page for authenticated users', async () => {
+    const agent = await loginAgent();
+    const res = await agent.get('/account');
+    expect(res.status).toBe(200);
+    expect(res.text).toContain('Account');
+    expect(res.text).toContain(FAKE_USER.email);
+  });
+});
+
+describe('POST /account/profile', () => {
+  test('redirects unauthenticated users to /login', async () => {
+    const res = await request(app).post('/account/profile').send({ email: 'new@example.com' });
+    expect(res.status).toBe(302);
+    expect(res.headers.location).toBe('/login');
+  });
+
+  test('updates profile and redirects to /account', async () => {
+    userModel.findByEmail.mockResolvedValue(null);
+    userModel.updateProfile.mockResolvedValue({ ...FAKE_USER, name: 'New Name', email: 'new@example.com' });
+    const agent = await loginAgent();
+
+    userModel.findByEmail.mockResolvedValue(null);
+    const res = await agent.post('/account/profile').send({ name: 'New Name', email: 'new@example.com' });
+    expect(res.status).toBe(302);
+    expect(res.headers.location).toBe('/account');
+    expect(userModel.updateProfile).toHaveBeenCalledWith(
+      FAKE_USER.id,
+      expect.objectContaining({ name: 'New Name', email: 'new@example.com' })
+    );
+  });
+
+  test('flashes error when email is missing', async () => {
+    const agent = await loginAgent();
+    const res = await agent.post('/account/profile').send({ name: 'Test', email: '' });
+    expect(res.status).toBe(302);
+    expect(res.headers.location).toBe('/account');
+    expect(userModel.updateProfile).not.toHaveBeenCalled();
+  });
+
+  test('flashes error when email is already taken by another user', async () => {
+    const agent = await loginAgent();
+    userModel.findByEmail.mockResolvedValue({ ...FAKE_USER, id: 'other-user-id' });
+    const res = await agent.post('/account/profile').send({ email: 'taken@example.com' });
+    expect(res.status).toBe(302);
+    expect(res.headers.location).toBe('/account');
+    expect(userModel.updateProfile).not.toHaveBeenCalled();
+  });
+});
+
+describe('POST /account/password', () => {
+  test('redirects unauthenticated users to /login', async () => {
+    const res = await request(app)
+      .post('/account/password')
+      .send({ currentPassword: 'old', newPassword: 'newpass1', confirmPassword: 'newpass1' });
+    expect(res.status).toBe(302);
+    expect(res.headers.location).toBe('/login');
+  });
+
+  test('changes password when current password is correct', async () => {
+    userModel.updatePassword.mockResolvedValue(FAKE_USER);
+    const agent = await loginAgent();
+
+    const bcrypt = require('bcrypt');
+    const hashedPassword = await bcrypt.hash('password123', 1);
+    userModel.findById.mockResolvedValue({ ...FAKE_USER, password: hashedPassword });
+
+    const res = await agent
+      .post('/account/password')
+      .send({ currentPassword: 'password123', newPassword: 'newpassword1', confirmPassword: 'newpassword1' });
+    expect(res.status).toBe(302);
+    expect(res.headers.location).toBe('/account');
+    expect(userModel.updatePassword).toHaveBeenCalledWith(FAKE_USER.id, 'newpassword1');
+  });
+
+  test('flashes error when current password is incorrect', async () => {
+    const agent = await loginAgent();
+
+    const bcrypt = require('bcrypt');
+    const hashedPassword = await bcrypt.hash('correct-password', 1);
+    userModel.findById.mockResolvedValue({ ...FAKE_USER, password: hashedPassword });
+
+    const res = await agent
+      .post('/account/password')
+      .send({ currentPassword: 'wrong-password', newPassword: 'newpassword1', confirmPassword: 'newpassword1' });
+    expect(res.status).toBe(302);
+    expect(res.headers.location).toBe('/account');
+    expect(userModel.updatePassword).not.toHaveBeenCalled();
+  });
+
+  test('flashes error when new passwords do not match', async () => {
+    const agent = await loginAgent();
+    const res = await agent
+      .post('/account/password')
+      .send({ currentPassword: 'password123', newPassword: 'newpass1', confirmPassword: 'different' });
+    expect(res.status).toBe(302);
+    expect(res.headers.location).toBe('/account');
+    expect(userModel.updatePassword).not.toHaveBeenCalled();
+  });
+
+  test('flashes error when new password is too short', async () => {
+    const agent = await loginAgent();
+    const res = await agent
+      .post('/account/password')
+      .send({ currentPassword: 'password123', newPassword: 'short', confirmPassword: 'short' });
+    expect(res.status).toBe(302);
+    expect(res.headers.location).toBe('/account');
+    expect(userModel.updatePassword).not.toHaveBeenCalled();
+  });
+
+  test('flashes error when fields are missing', async () => {
+    const agent = await loginAgent();
+    const res = await agent.post('/account/password').send({ currentPassword: 'password123' });
+    expect(res.status).toBe(302);
+    expect(res.headers.location).toBe('/account');
+    expect(userModel.updatePassword).not.toHaveBeenCalled();
+  });
+});

--- a/src/app.js
+++ b/src/app.js
@@ -7,6 +7,7 @@ const flash = require('express-flash');
 const authRoutes = require('./routes/authRoutes');
 const fileRoutes = require('./routes/fileRoutes');
 const folderRoutes = require('./routes/folderRoutes');
+const accountRoutes = require('./routes/accountRoutes');
 
 const PgStore = connectPgSimple(session);
 const app = express();
@@ -43,6 +44,7 @@ app.use(flash());
 app.use(authRoutes);
 app.use(fileRoutes);
 app.use(folderRoutes);
+app.use(accountRoutes);
 
 app.get('/api/test', (_req, res) => {
   res.json({ message: 'API is working!' });

--- a/src/controllers/accountController.js
+++ b/src/controllers/accountController.js
@@ -1,0 +1,73 @@
+const bcrypt = require('bcrypt');
+const userModel = require('../models/userModel');
+
+const getAccount = (req, res) => {
+  res.render('account', { user: req.user });
+};
+
+const updateProfile = async (req, res, next) => {
+  const { name, email } = req.body;
+
+  if (!email || !email.trim()) {
+    req.flash('error', 'Email is required.');
+    return res.redirect('/account');
+  }
+
+  try {
+    const existing = await userModel.findByEmail(email.trim());
+    if (existing && existing.id !== req.user.id) {
+      req.flash('error', 'That email is already in use.');
+      return res.redirect('/account');
+    }
+
+    const updated = await userModel.updateProfile(req.user.id, {
+      name: name ? name.trim() : null,
+      email: email.trim(),
+    });
+
+    req.user.name = updated.name;
+    req.user.email = updated.email;
+
+    req.flash('success', 'Profile updated.');
+    res.redirect('/account');
+  } catch (err) {
+    next(err);
+  }
+};
+
+const updatePassword = async (req, res, next) => {
+  const { currentPassword, newPassword, confirmPassword } = req.body;
+
+  if (!currentPassword || !newPassword || !confirmPassword) {
+    req.flash('error', 'All password fields are required.');
+    return res.redirect('/account');
+  }
+
+  if (newPassword !== confirmPassword) {
+    req.flash('error', 'New passwords do not match.');
+    return res.redirect('/account');
+  }
+
+  if (newPassword.length < 8) {
+    req.flash('error', 'New password must be at least 8 characters.');
+    return res.redirect('/account');
+  }
+
+  try {
+    const user = await userModel.findById(req.user.id);
+    const valid = await bcrypt.compare(currentPassword, user.password);
+
+    if (!valid) {
+      req.flash('error', 'Current password is incorrect.');
+      return res.redirect('/account');
+    }
+
+    await userModel.updatePassword(req.user.id, newPassword);
+    req.flash('success', 'Password changed.');
+    res.redirect('/account');
+  } catch (err) {
+    next(err);
+  }
+};
+
+module.exports = { getAccount, updateProfile, updatePassword };

--- a/src/models/userModel.js
+++ b/src/models/userModel.js
@@ -18,4 +18,13 @@ const createUser = async ({ email, password, name }) => {
   });
 };
 
-module.exports = { findByEmail, findById, createUser };
+const updateProfile = async (id, { name, email }) => {
+  return prisma.user.update({ where: { id }, data: { name, email } });
+};
+
+const updatePassword = async (id, newPassword) => {
+  const hashedPassword = await bcrypt.hash(newPassword, SALT_ROUNDS);
+  return prisma.user.update({ where: { id }, data: { password: hashedPassword } });
+};
+
+module.exports = { findByEmail, findById, createUser, updateProfile, updatePassword };

--- a/src/routes/accountRoutes.js
+++ b/src/routes/accountRoutes.js
@@ -1,0 +1,11 @@
+const express = require('express');
+const isAuthenticated = require('../middleware/isAuthenticated');
+const accountController = require('../controllers/accountController');
+
+const router = express.Router();
+
+router.get('/account', isAuthenticated, accountController.getAccount);
+router.post('/account/profile', isAuthenticated, accountController.updateProfile);
+router.post('/account/password', isAuthenticated, accountController.updatePassword);
+
+module.exports = router;

--- a/src/views/account.ejs
+++ b/src/views/account.ejs
@@ -1,0 +1,65 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Account - File Uploader</title>
+  <link rel="stylesheet" href="/style.css" />
+</head>
+<body>
+  <div class="page-wrap">
+
+    <div class="topbar">
+      <h1>Account</h1>
+      <div class="topbar-actions">
+        <a href="/dashboard" class="btn btn--ghost btn--sm">&larr; Dashboard</a>
+        <form action="/logout" method="POST" style="margin:0;">
+          <button type="submit" class="btn--logout">Log out</button>
+        </form>
+      </div>
+    </div>
+
+    <% if (messages && messages.error && messages.error.length > 0) { %>
+      <div class="flash flash--error"><%= messages.error[0] %></div>
+    <% } %>
+    <% if (messages && messages.success && messages.success.length > 0) { %>
+      <div class="flash flash--success"><%= messages.success[0] %></div>
+    <% } %>
+
+    <div class="card">
+      <h2>Profile</h2>
+      <form action="/account/profile" method="POST">
+        <div class="form-group">
+          <label for="name">Name</label>
+          <input type="text" id="name" name="name" value="<%= user.name || '' %>" />
+        </div>
+        <div class="form-group">
+          <label for="email">Email</label>
+          <input type="email" id="email" name="email" value="<%= user.email %>" required />
+        </div>
+        <button type="submit" class="btn btn--primary btn--sm">Save Profile</button>
+      </form>
+    </div>
+
+    <div class="card">
+      <h2>Change Password</h2>
+      <form action="/account/password" method="POST">
+        <div class="form-group">
+          <label for="currentPassword">Current Password</label>
+          <input type="password" id="currentPassword" name="currentPassword" required />
+        </div>
+        <div class="form-group">
+          <label for="newPassword">New Password</label>
+          <input type="password" id="newPassword" name="newPassword" required minlength="8" />
+        </div>
+        <div class="form-group">
+          <label for="confirmPassword">Confirm New Password</label>
+          <input type="password" id="confirmPassword" name="confirmPassword" required minlength="8" />
+        </div>
+        <button type="submit" class="btn btn--primary btn--sm">Change Password</button>
+      </form>
+    </div>
+
+  </div>
+</body>
+</html>

--- a/src/views/dashboard.ejs
+++ b/src/views/dashboard.ejs
@@ -19,6 +19,7 @@
             <a href="/dashboard">Folders</a> &nbsp;|&nbsp; <span class="active">Flat</span>
           <% } %>
         </span>
+        <a href="/account" class="btn btn--ghost btn--sm">Account</a>
         <form action="/logout" method="POST" style="margin:0;">
           <button type="submit" class="btn--logout">Log out</button>
         </form>


### PR DESCRIPTION
## Summary
- `GET /account` — view profile page
- `POST /account/profile` — update name and email (with duplicate-email check)
- `POST /account/password` — change password (verify current, 8-char min, confirm match)
- New `account.ejs` view with styled forms
- Account link added to dashboard topbar
- 12 new tests (62 total across 5 test suites)

🤖 Generated with [Claude Code](https://claude.com/claude-code)