### PR TITLE
feat(auth): password reset via email token

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -69,6 +69,8 @@ Required vars:
 - `SUPABASE_URL` — Supabase project URL
 - `SUPABASE_ANON_KEY` — Supabase anon/public key
 - `SUPABASE_STORAGE_BUCKET` — Supabase storage bucket name
+- `SMTP_HOST` / `SMTP_PORT` / `SMTP_USER` / `SMTP_PASS` — SMTP credentials for sending password reset emails (optional; falls back to Ethereal test accounts in development)
+- `EMAIL_FROM` — Sender address for outgoing mail (e.g. `"File Uploader" <noreply@example.com>`)
 
 ## Deployment
 

--- a/__tests__/account.test.js
+++ b/__tests__/account.test.js
@@ -10,6 +10,7 @@ jest.mock('connect-pg-simple', () => {
 jest.mock('../src/models/userModel');
 jest.mock('../src/models/fileModel');
 jest.mock('../src/models/folderModel');
+jest.mock('../src/models/passwordResetModel');
 jest.mock('../src/config/supabase', () => ({
   storage: {
     from: jest.fn(() => ({

--- a/__tests__/app.test.js
+++ b/__tests__/app.test.js
@@ -10,6 +10,7 @@ jest.mock('connect-pg-simple', () => {
 jest.mock('../src/models/userModel');
 jest.mock('../src/models/fileModel');
 jest.mock('../src/models/folderModel');
+jest.mock('../src/models/passwordResetModel');
 jest.mock('../src/config/supabase', () => ({
   storage: {
     from: jest.fn(() => ({

--- a/__tests__/auth.test.js
+++ b/__tests__/auth.test.js
@@ -10,6 +10,7 @@ jest.mock('connect-pg-simple', () => {
 jest.mock('../src/models/userModel');
 jest.mock('../src/models/fileModel');
 jest.mock('../src/models/folderModel');
+jest.mock('../src/models/passwordResetModel');
 jest.mock('../src/config/supabase', () => ({
   storage: {
     from: jest.fn(() => ({

--- a/__tests__/file.test.js
+++ b/__tests__/file.test.js
@@ -10,6 +10,7 @@ jest.mock('connect-pg-simple', () => {
 jest.mock('../src/models/userModel');
 jest.mock('../src/models/fileModel');
 jest.mock('../src/models/folderModel');
+jest.mock('../src/models/passwordResetModel');
 jest.mock('../src/config/supabase', () => ({
   storage: {
     from: jest.fn(() => ({

--- a/__tests__/folder.test.js
+++ b/__tests__/folder.test.js
@@ -10,6 +10,7 @@ jest.mock('connect-pg-simple', () => {
 jest.mock('../src/models/userModel');
 jest.mock('../src/models/fileModel');
 jest.mock('../src/models/folderModel');
+jest.mock('../src/models/passwordResetModel');
 jest.mock('../src/config/supabase', () => ({
   storage: {
     from: jest.fn(() => ({

--- a/__tests__/password-reset.test.js
+++ b/__tests__/password-reset.test.js
@@ -1,0 +1,197 @@
+const request = require('supertest');
+
+jest.mock('connect-pg-simple', () => {
+  return () => {
+    const session = require('express-session');
+    return session.MemoryStore;
+  };
+});
+
+jest.mock('../src/models/userModel');
+jest.mock('../src/models/fileModel');
+jest.mock('../src/models/folderModel');
+jest.mock('../src/models/passwordResetModel');
+jest.mock('../src/config/supabase', () => ({
+  storage: {
+    from: jest.fn(() => ({
+      upload: jest.fn().mockResolvedValue({ data: {}, error: null }),
+      getPublicUrl: jest.fn().mockReturnValue({ data: { publicUrl: 'https://test.supabase.co/...' } }),
+      remove: jest.fn().mockResolvedValue({ data: {}, error: null }),
+      createSignedUrl: jest.fn().mockResolvedValue({ data: { signedUrl: 'https://test.supabase.co/signed/test' }, error: null }),
+    })),
+  },
+}));
+
+const userModel = require('../src/models/userModel');
+const fileModel = require('../src/models/fileModel');
+const folderModel = require('../src/models/folderModel');
+const passwordResetModel = require('../src/models/passwordResetModel');
+const app = require('../src/app');
+
+const FAKE_USER = {
+  id: 'uuid-test-1',
+  email: 'test@example.com',
+  password: '$2b$12$hashedpassword',
+  name: 'Test User',
+};
+
+const VALID_TOKEN = 'a'.repeat(64);
+const FAKE_TOKEN_RECORD = {
+  id: 'token-uuid-1',
+  token: VALID_TOKEN,
+  userId: FAKE_USER.id,
+  user: FAKE_USER,
+  expiresAt: new Date(Date.now() + 60 * 60 * 1000), // 1 hour from now
+};
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  fileModel.getRootFiles.mockResolvedValue([]);
+  fileModel.countRootFiles.mockResolvedValue(0);
+  folderModel.getFoldersByUser.mockResolvedValue([]);
+});
+
+describe('GET /forgot-password', () => {
+  test('renders the forgot password form', async () => {
+    const res = await request(app).get('/forgot-password');
+    expect(res.status).toBe(200);
+    expect(res.text).toContain('Forgot Password');
+    expect(res.text).toContain('Send Reset Link');
+  });
+});
+
+describe('POST /forgot-password', () => {
+  test('redirects with success flash when email belongs to a registered user', async () => {
+    userModel.findByEmail.mockResolvedValue(FAKE_USER);
+    passwordResetModel.createToken.mockResolvedValue(FAKE_TOKEN_RECORD);
+
+    const res = await request(app).post('/forgot-password').send({ email: 'test@example.com' });
+    expect(res.status).toBe(302);
+    expect(res.headers.location).toBe('/forgot-password');
+    expect(passwordResetModel.createToken).toHaveBeenCalledWith(
+      FAKE_USER.id,
+      expect.any(String),
+      expect.any(Date)
+    );
+  });
+
+  test('redirects with success flash even when email is not registered (no enumeration)', async () => {
+    userModel.findByEmail.mockResolvedValue(null);
+
+    const res = await request(app).post('/forgot-password').send({ email: 'nobody@example.com' });
+    expect(res.status).toBe(302);
+    expect(res.headers.location).toBe('/forgot-password');
+    expect(passwordResetModel.createToken).not.toHaveBeenCalled();
+  });
+
+  test('redirects with error flash when email is missing', async () => {
+    const res = await request(app).post('/forgot-password').send({});
+    expect(res.status).toBe(302);
+    expect(res.headers.location).toBe('/forgot-password');
+    expect(passwordResetModel.createToken).not.toHaveBeenCalled();
+  });
+});
+
+describe('GET /reset-password/:token', () => {
+  test('renders reset form for a valid, unexpired token', async () => {
+    passwordResetModel.findByToken.mockResolvedValue(FAKE_TOKEN_RECORD);
+
+    const res = await request(app).get(`/reset-password/${VALID_TOKEN}`);
+    expect(res.status).toBe(200);
+    expect(res.text).toContain('Reset Password');
+    expect(res.text).toContain('Set New Password');
+  });
+
+  test('redirects to /forgot-password for an expired token', async () => {
+    passwordResetModel.findByToken.mockResolvedValue({
+      ...FAKE_TOKEN_RECORD,
+      expiresAt: new Date(Date.now() - 1000), // expired
+    });
+
+    const res = await request(app).get(`/reset-password/${VALID_TOKEN}`);
+    expect(res.status).toBe(302);
+    expect(res.headers.location).toBe('/forgot-password');
+  });
+
+  test('redirects to /forgot-password for an invalid (not found) token', async () => {
+    passwordResetModel.findByToken.mockResolvedValue(null);
+
+    const res = await request(app).get('/reset-password/invalid-token');
+    expect(res.status).toBe(302);
+    expect(res.headers.location).toBe('/forgot-password');
+  });
+});
+
+describe('POST /reset-password/:token', () => {
+  test('updates password and redirects to /login on success', async () => {
+    passwordResetModel.findByToken.mockResolvedValue(FAKE_TOKEN_RECORD);
+    userModel.updatePassword.mockResolvedValue(FAKE_USER);
+    passwordResetModel.deleteByToken.mockResolvedValue(FAKE_TOKEN_RECORD);
+
+    const res = await request(app)
+      .post(`/reset-password/${VALID_TOKEN}`)
+      .send({ newPassword: 'newpassword1', confirmPassword: 'newpassword1' });
+
+    expect(res.status).toBe(302);
+    expect(res.headers.location).toBe('/login');
+    expect(userModel.updatePassword).toHaveBeenCalledWith(FAKE_USER.id, 'newpassword1');
+    expect(passwordResetModel.deleteByToken).toHaveBeenCalledWith(VALID_TOKEN);
+  });
+
+  test('redirects to /forgot-password when token is expired', async () => {
+    passwordResetModel.findByToken.mockResolvedValue({
+      ...FAKE_TOKEN_RECORD,
+      expiresAt: new Date(Date.now() - 1000),
+    });
+
+    const res = await request(app)
+      .post(`/reset-password/${VALID_TOKEN}`)
+      .send({ newPassword: 'newpassword1', confirmPassword: 'newpassword1' });
+
+    expect(res.status).toBe(302);
+    expect(res.headers.location).toBe('/forgot-password');
+    expect(userModel.updatePassword).not.toHaveBeenCalled();
+  });
+
+  test('redirects to /forgot-password when token is invalid', async () => {
+    passwordResetModel.findByToken.mockResolvedValue(null);
+
+    const res = await request(app)
+      .post('/reset-password/bad-token')
+      .send({ newPassword: 'newpassword1', confirmPassword: 'newpassword1' });
+
+    expect(res.status).toBe(302);
+    expect(res.headers.location).toBe('/forgot-password');
+    expect(userModel.updatePassword).not.toHaveBeenCalled();
+  });
+
+  test('flashes error and redirects back when passwords do not match', async () => {
+    const res = await request(app)
+      .post(`/reset-password/${VALID_TOKEN}`)
+      .send({ newPassword: 'newpassword1', confirmPassword: 'differentpassword' });
+
+    expect(res.status).toBe(302);
+    expect(res.headers.location).toBe(`/reset-password/${VALID_TOKEN}`);
+    expect(userModel.updatePassword).not.toHaveBeenCalled();
+  });
+
+  test('flashes error and redirects back when password is too short', async () => {
+    const res = await request(app)
+      .post(`/reset-password/${VALID_TOKEN}`)
+      .send({ newPassword: 'short', confirmPassword: 'short' });
+
+    expect(res.status).toBe(302);
+    expect(res.headers.location).toBe(`/reset-password/${VALID_TOKEN}`);
+    expect(userModel.updatePassword).not.toHaveBeenCalled();
+  });
+
+  test('flashes error and redirects back when fields are missing', async () => {
+    const res = await request(app)
+      .post(`/reset-password/${VALID_TOKEN}`)
+      .send({ newPassword: 'newpassword1' });
+
+    expect(res.status).toBe(302);
+    expect(res.headers.location).toBe(`/reset-password/${VALID_TOKEN}`);
+    expect(userModel.updatePassword).not.toHaveBeenCalled();
+  });
+});

--- a/package-lock.json
+++ b/package-lock.json
@@ -16,6 +16,7 @@
         "express-flash": "^0.0.2",
         "express-session": "^1.18.1",
         "multer": "^1.4.5-lts.1",
+        "nodemailer": "^8.0.1",
         "passport": "^0.7.0",
         "passport-local": "^1.0.0",
         "prisma": "^6.3.1"
@@ -5109,6 +5110,15 @@
       "integrity": "sha512-xxOWJsBKtzAq7DY0J+DTzuz58K8e7sJbdgwkbMWQe8UYB6ekmsQ45q0M/tJDsGaZmbC+l7n57UV8Hl5tHxO9uw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/nodemailer": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/nodemailer/-/nodemailer-8.0.1.tgz",
+      "integrity": "sha512-5kcldIXmaEjZcHR6F28IKGSgpmZHaF1IXLWFTG+Xh3S+Cce4MiakLtWY+PlBU69fLbRa8HlaGIrC/QolUpHkhg==",
+      "license": "MIT-0",
+      "engines": {
+        "node": ">=6.0.0"
+      }
     },
     "node_modules/nopt": {
       "version": "5.0.0",

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "express-flash": "^0.0.2",
     "express-session": "^1.18.1",
     "multer": "^1.4.5-lts.1",
+    "nodemailer": "^8.0.1",
     "passport": "^0.7.0",
     "passport-local": "^1.0.0",
     "prisma": "^6.3.1"

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -20,8 +20,9 @@ model User {
   name      String?
   createdAt DateTime @default(now())
   updatedAt DateTime @updatedAt
-  files     File[]
-  folders   Folder[]
+  files               File[]
+  folders             Folder[]
+  passwordResetTokens PasswordResetToken[]
 }
 
 model File {
@@ -49,6 +50,17 @@ model Folder {
   userId    String
   user      User     @relation(fields: [userId], references: [id])
   files     File[]
+
+  @@index([userId])
+}
+
+model PasswordResetToken {
+  id        String   @id @default(uuid())
+  token     String   @unique
+  userId    String
+  user      User     @relation(fields: [userId], references: [id])
+  expiresAt DateTime
+  createdAt DateTime @default(now())
 
   @@index([userId])
 }

--- a/src/app.js
+++ b/src/app.js
@@ -8,6 +8,7 @@ const authRoutes = require('./routes/authRoutes');
 const fileRoutes = require('./routes/fileRoutes');
 const folderRoutes = require('./routes/folderRoutes');
 const accountRoutes = require('./routes/accountRoutes');
+const passwordResetRoutes = require('./routes/passwordResetRoutes');
 
 const PgStore = connectPgSimple(session);
 const app = express();
@@ -45,6 +46,7 @@ app.use(authRoutes);
 app.use(fileRoutes);
 app.use(folderRoutes);
 app.use(accountRoutes);
+app.use(passwordResetRoutes);
 
 app.get('/api/test', (_req, res) => {
   res.json({ message: 'API is working!' });

--- a/src/config/mailer.js
+++ b/src/config/mailer.js
@@ -1,0 +1,55 @@
+const nodemailer = require('nodemailer');
+
+let transporter = null;
+
+const getTransporter = async () => {
+  if (transporter) return transporter;
+
+  if (process.env.NODE_ENV === 'test') {
+    transporter = { sendMail: async () => ({ messageId: 'test-message-id' }) };
+    return transporter;
+  }
+
+  if (process.env.SMTP_HOST) {
+    transporter = nodemailer.createTransport({
+      host: process.env.SMTP_HOST,
+      port: parseInt(process.env.SMTP_PORT, 10) || 587,
+      secure: process.env.SMTP_SECURE === 'true',
+      auth: {
+        user: process.env.SMTP_USER,
+        pass: process.env.SMTP_PASS,
+      },
+    });
+  } else {
+    const testAccount = await nodemailer.createTestAccount();
+    transporter = nodemailer.createTransport({
+      host: 'smtp.ethereal.email',
+      port: 587,
+      auth: { user: testAccount.user, pass: testAccount.pass },
+    });
+    console.warn('No SMTP_HOST set — using Ethereal test account:', testAccount.user);
+  }
+
+  return transporter;
+};
+
+const sendMail = async ({ to, subject, html }) => {
+  const t = await getTransporter();
+  const info = await t.sendMail({
+    from: process.env.EMAIL_FROM || '"File Uploader" <noreply@example.com>',
+    to,
+    subject,
+    html,
+  });
+
+  if (process.env.NODE_ENV !== 'production') {
+    const previewUrl = nodemailer.getTestMessageUrl && nodemailer.getTestMessageUrl(info);
+    if (previewUrl) {
+      console.warn(`Email preview: ${previewUrl}`);
+    }
+  }
+
+  return info;
+};
+
+module.exports = { sendMail };

--- a/src/controllers/passwordResetController.js
+++ b/src/controllers/passwordResetController.js
@@ -1,0 +1,103 @@
+const crypto = require('crypto');
+const userModel = require('../models/userModel');
+const passwordResetModel = require('../models/passwordResetModel');
+const { sendMail } = require('../config/mailer');
+
+const TOKEN_TTL_MS = 60 * 60 * 1000; // 1 hour
+
+const getForgotPassword = (req, res) => {
+  res.render('forgot-password');
+};
+
+const postForgotPassword = async (req, res, next) => {
+  const { email } = req.body;
+
+  if (!email) {
+    req.flash('error', 'Please enter your email address.');
+    return res.redirect('/forgot-password');
+  }
+
+  try {
+    const user = await userModel.findByEmail(email.trim().toLowerCase());
+
+    if (user) {
+      const token = crypto.randomBytes(32).toString('hex');
+      const expiresAt = new Date(Date.now() + TOKEN_TTL_MS);
+      await passwordResetModel.createToken(user.id, token, expiresAt);
+
+      const baseUrl = `${req.protocol}://${req.get('host')}`;
+      const resetLink = `${baseUrl}/reset-password/${token}`;
+
+      await sendMail({
+        to: user.email,
+        subject: 'Reset your File Uploader password',
+        html: `
+          <p>Hi ${user.name || user.email},</p>
+          <p>You requested a password reset. Click the link below — it expires in 1 hour.</p>
+          <p><a href="${resetLink}">${resetLink}</a></p>
+          <p>If you did not request this, you can safely ignore this email.</p>
+        `,
+      });
+    }
+
+    // Always show the same message to prevent email enumeration
+    req.flash('success', 'If that email is registered, a reset link has been sent.');
+    res.redirect('/forgot-password');
+  } catch (err) {
+    next(err);
+  }
+};
+
+const getResetPassword = async (req, res, next) => {
+  try {
+    const record = await passwordResetModel.findByToken(req.params.token);
+
+    if (!record || record.expiresAt < new Date()) {
+      req.flash('error', 'This reset link is invalid or has expired.');
+      return res.redirect('/forgot-password');
+    }
+
+    res.render('reset-password', { token: req.params.token });
+  } catch (err) {
+    next(err);
+  }
+};
+
+const postResetPassword = async (req, res, next) => {
+  const { newPassword, confirmPassword } = req.body;
+  const { token } = req.params;
+
+  if (!newPassword || !confirmPassword) {
+    req.flash('error', 'Please fill in all fields.');
+    return res.redirect(`/reset-password/${token}`);
+  }
+
+  if (newPassword !== confirmPassword) {
+    req.flash('error', 'Passwords do not match.');
+    return res.redirect(`/reset-password/${token}`);
+  }
+
+  if (newPassword.length < 8) {
+    req.flash('error', 'Password must be at least 8 characters.');
+    return res.redirect(`/reset-password/${token}`);
+  }
+
+  try {
+    const record = await passwordResetModel.findByToken(token);
+
+    if (!record || record.expiresAt < new Date()) {
+      req.flash('error', 'This reset link is invalid or has expired.');
+      return res.redirect('/forgot-password');
+    }
+
+    await userModel.updatePassword(record.userId, newPassword);
+    await passwordResetModel.deleteByToken(token);
+
+    req.flash('success', 'Password updated. You can now log in.');
+    res.redirect('/login');
+  } catch (err) {
+    next(err);
+  }
+};
+
+module.exports = { getForgotPassword, postForgotPassword, getResetPassword, postResetPassword };

--- a/src/models/passwordResetModel.js
+++ b/src/models/passwordResetModel.js
@@ -1,0 +1,21 @@
+const prisma = require('../config/prisma');
+
+const createToken = async (userId, token, expiresAt) => {
+  await prisma.passwordResetToken.deleteMany({ where: { userId } });
+  return prisma.passwordResetToken.create({
+    data: { userId, token, expiresAt },
+  });
+};
+
+const findByToken = async (token) => {
+  return prisma.passwordResetToken.findUnique({
+    where: { token },
+    include: { user: true },
+  });
+};
+
+const deleteByToken = async (token) => {
+  return prisma.passwordResetToken.delete({ where: { token } });
+};
+
+module.exports = { createToken, findByToken, deleteByToken };

--- a/src/routes/passwordResetRoutes.js
+++ b/src/routes/passwordResetRoutes.js
@@ -1,0 +1,10 @@
+const express = require('express');
+const router = express.Router();
+const passwordResetController = require('../controllers/passwordResetController');
+
+router.get('/forgot-password', passwordResetController.getForgotPassword);
+router.post('/forgot-password', passwordResetController.postForgotPassword);
+router.get('/reset-password/:token', passwordResetController.getResetPassword);
+router.post('/reset-password/:token', passwordResetController.postResetPassword);
+
+module.exports = router;

--- a/src/views/forgot-password.ejs
+++ b/src/views/forgot-password.ejs
@@ -3,12 +3,12 @@
 <head>
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-  <title>Log In - File Uploader</title>
+  <title>Forgot Password - File Uploader</title>
   <link rel="stylesheet" href="/style.css" />
 </head>
 <body>
   <div class="auth-card">
-    <h1>Log In</h1>
+    <h1>Forgot Password</h1>
 
     <% if (messages && messages.error && messages.error.length > 0) { %>
       <div class="flash flash--error"><%= messages.error[0] %></div>
@@ -17,20 +17,17 @@
       <div class="flash flash--success"><%= messages.success[0] %></div>
     <% } %>
 
-    <form action="/login" method="POST">
+    <p style="color: var(--muted); margin-bottom: 1.5rem;">Enter your email and we'll send you a reset link.</p>
+
+    <form action="/forgot-password" method="POST">
       <div class="form-group">
         <label for="email">Email</label>
         <input type="email" id="email" name="email" required />
       </div>
-      <div class="form-group">
-        <label for="password">Password</label>
-        <input type="password" id="password" name="password" required />
-      </div>
-      <button type="submit" class="btn btn--primary">Log In</button>
+      <button type="submit" class="btn btn--primary">Send Reset Link</button>
     </form>
 
-    <p><a href="/forgot-password">Forgot your password?</a></p>
-    <p>Don't have an account? <a href="/signup">Sign up</a></p>
+    <p><a href="/login">&larr; Back to Log In</a></p>
   </div>
 </body>
 </html>

--- a/src/views/reset-password.ejs
+++ b/src/views/reset-password.ejs
@@ -1,0 +1,32 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Reset Password - File Uploader</title>
+  <link rel="stylesheet" href="/style.css" />
+</head>
+<body>
+  <div class="auth-card">
+    <h1>Reset Password</h1>
+
+    <% if (messages && messages.error && messages.error.length > 0) { %>
+      <div class="flash flash--error"><%= messages.error[0] %></div>
+    <% } %>
+
+    <form action="/reset-password/<%= token %>" method="POST">
+      <div class="form-group">
+        <label for="newPassword">New Password</label>
+        <input type="password" id="newPassword" name="newPassword" required minlength="8" />
+      </div>
+      <div class="form-group">
+        <label for="confirmPassword">Confirm New Password</label>
+        <input type="password" id="confirmPassword" name="confirmPassword" required minlength="8" />
+      </div>
+      <button type="submit" class="btn btn--primary">Set New Password</button>
+    </form>
+
+    <p><a href="/forgot-password">&larr; Back</a></p>
+  </div>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- Adds a complete forgot-password / reset-password flow
- `POST /forgot-password` generates a secure 64-char random token (1-hour TTL), stores it in a new `PasswordResetToken` Prisma model, and emails a reset link
- `GET /reset-password/:token` validates the token and renders the reset form
- `POST /reset-password/:token` validates the token, updates the password, and deletes the token
- Email sent via Nodemailer — uses Ethereal auto-accounts in development (preview URL logged to console), SMTP env vars in production
- "Forgot your password?" link added to the login page
- Existing email enumeration protected: success flash shown regardless of whether the email is registered

## New env vars (Railway)
| Var | Purpose |
|---|---|
| `SMTP_HOST` / `SMTP_PORT` / `SMTP_USER` / `SMTP_PASS` | SMTP credentials |
| `EMAIL_FROM` | Sender address (e.g. `"File Uploader" <noreply@example.com>`) |

## Migration required
After merging, run on Railway:
```
railway run npx prisma migrate deploy
```
(or via Railway shell — adds the `PasswordResetToken` table)

## Test plan
- [ ] 75 tests across 6 suites, all passing (`npm test`)
- [ ] `GET /forgot-password` renders the form
- [ ] Submit with a registered email → success flash, email preview URL logged in dev console
- [ ] Submit with an unknown email → same success flash (no enumeration)
- [ ] Click reset link → renders password form
- [ ] Submit matching passwords (≥8 chars) → redirects to `/login` with success flash
- [ ] Submit with expired/invalid token → redirects to `/forgot-password` with error
- [ ] Submit mismatched passwords → error flash, stays on reset form
- [ ] After successful reset, old reset link is invalid (token deleted)

🤖 Generated with [Claude Code](https://claude.com/claude-code)